### PR TITLE
Fixed test cases

### DIFF
--- a/sources/OpenMcdf/OpenMcdf.csproj
+++ b/sources/OpenMcdf/OpenMcdf.csproj
@@ -44,6 +44,7 @@
     <DocumentationFile>..\..\bin\Debug\OpenMcdf\OpenMcdf.xml</DocumentationFile>
     <NoWarn>1591,1592,1573,1571,1570,1572</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
+++ b/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
@@ -60,6 +60,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /S "$(SolutionDir)sources\Test\TestFiles\*" "$(TargetDir)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
+++ b/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
@@ -112,6 +112,9 @@
     <None Include="OpenMcdf.snk" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /S "$(SolutionDir)sources\Test\TestFiles\*" "$(TargetDir)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Fixed the following test cases by changing the OpenMCDF project's build setting Platform Target to x64:
- Test_FIX_BUG_GH_14
- Test_FIX_BUG_GH_15

Also, added a post-build event command to copy TestFiles to the target directory (Debug or Release).

