### PR TITLE
closes ironfede/openmcdf#24

### DIFF
--- a/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
+++ b/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
@@ -3,6 +3,8 @@
      <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
     <AssemblyOriginatorKeyFile>OpenMcdf.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/sources/OpenMcdf/OpenMcdf.csproj
+++ b/sources/OpenMcdf/OpenMcdf.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
     <AssemblyOriginatorKeyFile>OpenMcdf.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
* Closing issue #24 

Tests are still green 
The following is a trace of the results on my local machine:
 
Successfully created package 'XXX\Projects\openmcdf\bin\Debug\OpenMcdf\OpenMcdf.1.0.0.nupkg'.
 Successfully created package 'XXX\Projects\openmcdf\bin\Debug\OpenMcdf\OpenMcdf.1.0.0.symbols.nupkg'.
  Successfully created package 'XXX\Projects\openmcdf\bin\Debug\OpenMcdf.Extensions\OpenMcdf.Extensions.1.0.0.nupkg'.
  Successfully created package 'XXX\Projects\openmcdf\bin\Debug\OpenMcdf.Extensions\OpenMcdf.Extensions.1.0.0.symbols.nupkg'.
![openmcdf](https://user-images.githubusercontent.com/3293/43041781-726086c4-8d38-11e8-8ea9-b0fb421fbc67.png)