### PR TITLE
saving config in constructors

### DIFF
--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -369,6 +369,7 @@ namespace OpenMcdf
         /// </example>
         public CompoundFile(String fileName, CFSUpdateMode updateMode, CFSConfiguration configParameters)
         {
+            this.configuration = configParameters;
             this.validationExceptionEnabled = !configParameters.HasFlag(CFSConfiguration.NoValidationException);
             this.sectorRecycle = configParameters.HasFlag(CFSConfiguration.SectorRecycle);
             this.updateMode = updateMode;
@@ -416,6 +417,7 @@ namespace OpenMcdf
         /// <exception cref="T:OpenMcdf.CFException">Raised stream is null</exception>
         public CompoundFile(Stream stream, CFSUpdateMode updateMode, CFSConfiguration configParameters)
         {
+            this.configuration = configParameters;
             this.validationExceptionEnabled = !configParameters.HasFlag(CFSConfiguration.NoValidationException);
             this.sectorRecycle = configParameters.HasFlag(CFSConfiguration.SectorRecycle);
             this.eraseFreeSectors = configParameters.HasFlag(CFSConfiguration.EraseFreeSectors);


### PR DESCRIPTION
some of the constructors of CompoundFile that took in a config were not setting the config field. this led to an issue where if the LeaveOpen flag was set, calling Close() would still close the stream.