### PR TITLE
Changes for adding .NET Framework 3.5 support

### DIFF
--- a/sources/OpenMcdf/OpenMcdf.csproj
+++ b/sources/OpenMcdf/OpenMcdf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40;net35</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Be.Windows.Forms;
 using OpenMcdf;
 
@@ -27,7 +25,7 @@ namespace StructuredStorageExplorer
         /// <summary>
         /// Initializes a new instance of the DynamicByteProvider class.
         /// </summary>
-        /// <param name="bytes"></param>
+        /// <param name="modifiedStream"></param>
         public StreamDataProvider(CFStream modifiedStream)
         {
             _bytes = new ByteCollection(modifiedStream.GetData());

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 
 namespace OpenMcdf.Extensions.Test
 {
@@ -160,7 +159,8 @@ namespace OpenMcdf.Extensions.Test
 
                     Assert.IsNotNull(co2.Properties);
                 }
-            }catch(Exception ex)
+            }
+            catch (Exception)
             {
                 Assert.Fail();
             }
@@ -199,7 +199,7 @@ namespace OpenMcdf.Extensions.Test
                         Debug.WriteLine(p.Value);
                     }
 
-                    
+
                     Assert.IsNotNull(co2.UserDefinedProperties.Properties);
                     foreach (OLEProperties.OLEProperty p in co2.UserDefinedProperties.Properties)
                     {
@@ -211,7 +211,7 @@ namespace OpenMcdf.Extensions.Test
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.Fail();
             }

--- a/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
+++ b/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
@@ -16,9 +16,9 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\TestFiles\*.*">

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Text;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenMcdf;
-using System.IO;
-using System.Diagnostics;
 
 namespace OpenMcdf.Test
 {
@@ -780,12 +778,10 @@ namespace OpenMcdf.Test
                 CompoundFile file = new CompoundFile(fs, CFSUpdateMode.ReadOnly, CFSConfiguration.LeaveOpen);
 
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
             }
-
-
         }
 
         [TestMethod]
@@ -810,7 +806,7 @@ namespace OpenMcdf.Test
                 cf2.Commit();
                 cf2.Close();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
             }
@@ -988,7 +984,7 @@ namespace OpenMcdf.Test
             byte c = 0x0A;
             for (int i = 0; i < iterationCount; i++)
             {
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + 0.ToString()).Read(readBuffer, ((long)BUFFER_SIZE + ((long)BUFFER_SIZE * i)) - 15, 15);
+                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + 0.ToString()).Read(readBuffer, (BUFFER_SIZE + ((long)BUFFER_SIZE * i)) - 15, 15);
                 Assert.IsTrue(readBuffer.All(by => by == c));
                 c++;
             }
@@ -1008,7 +1004,7 @@ namespace OpenMcdf.Test
                 Assert.IsTrue(st.GetData().Count() == 31220);
                 f.Close();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.Fail("Release Memory flag caused error");
             }
@@ -1054,27 +1050,27 @@ namespace OpenMcdf.Test
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Doc()
         {
-	        var f = new CompoundFile("corrupted-sector-chain.doc");
+            var f = new CompoundFile("corrupted-sector-chain.doc");
 
-	        f.Close();
-        } 
-        
+            f.Close();
+        }
+
         [TestMethod]
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Cfs()
         {
-	        var f = new CompoundFile("corrupted-sector-chain.cfs");
+            var f = new CompoundFile("corrupted-sector-chain.cfs");
 
-	        f.Close();
+            f.Close();
         }
 
         [TestMethod]
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Doc2()
         {
-	        var f = new CompoundFile("corrupted-sector-chain-2.doc");
+            var f = new CompoundFile("corrupted-sector-chain-2.doc");
 
-	        f.Close();
+            f.Close();
         }
 
         //[TestMethod]

--- a/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
+++ b/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
@@ -75,9 +75,9 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\TestFiles\*.*">


### PR DESCRIPTION
These changes bring .NET Framework 3.5 support for Open MCDF. I was working on a private project where I had to read the old binary Office formats in a .NET Framework 3.5 application, and Open MCDF was wonderful for .NET 4.x and .NET Core apps. So I decided to add a bit of my knowledge to bring support for .NET 3.5.

I ran the existing unit test projects and all of them passed, so I think this could be helpful for any other users of this library that are stuck in .NET Framework 3.5 :) 