### PR TITLE
Fix invalid cyclic validation when reaching the end of the difatStream

### DIFF
--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -1407,6 +1407,8 @@ namespace OpenMcdf
                         continue;
                     }
 
+                    EnsureUniqueSectorIndex(nextSecID, processedSectors);
+
                     Sector s = sectors[nextSecID] as Sector;
 
                     if (s == null)
@@ -1421,7 +1423,6 @@ namespace OpenMcdf
 
                     difatStream.Read(nextDIFATSectorBuffer, 0, 4);
                     nextSecID = BitConverter.ToInt32(nextDIFATSectorBuffer, 0);
-                    EnsureUniqueSectorIndex(nextSecID, processedSectors);
                     nFat++;
                 }
             }

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -1077,6 +1077,26 @@ namespace OpenMcdf.Test
 	        f.Close();
         }
 
+        [TestMethod]
+        public void Test_WRONG_CORRUPTED_EXCEPTION()
+        {
+            var cf = new CompoundFile();
+
+            for (int i = 0; i < 100; i++)
+            {
+                cf.RootStorage.AddStream("Stream" + i).SetData(Helpers.GetBuffer(100000, 0xAA));
+            }
+            
+            cf.RootStorage.AddStream("BigStream").SetData(Helpers.GetBuffer(5250000, 0xAA));
+
+            using (var stream = new MemoryStream())
+            {
+                cf.Save(stream);
+            }
+
+            cf.Close();
+        }
+
         //[TestMethod]
         //public void Test_CORRUPTED_CYCLIC_DIFAT_VALIDATION_CHECK()
         //{


### PR DESCRIPTION
The HashSet based cyclic sector validation sometimes cares about extra sector ids. This can lead to unexpected exceptions thrown when the last sector is precisely at the end of the difatStream.

This MR moves that validation to only care about sectors that will be used, and adds a unit test to highlight/cover the issue.