### PR TITLE
Add `IEnumerable<CFItem> EnumerateChildren()` to CFStorage

### DIFF
--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenMcdf;
 
@@ -124,6 +125,10 @@ namespace OpenMcdf.Test
             foreach (var item2 in stg.EnumerateChildren(true))
                 if (item2.Name == "AnotherStream") found = true;
             Assert.IsTrue(found);
+
+            Assert.AreEqual(stg.EnumerateChildren(true).Where(e => e.IsStorage).Count(), 1);
+            Assert.AreEqual(stg.EnumerateChildren(false).Where(e => e.Name.Contains("Stream")).Count(), 2);
+            Assert.AreEqual(stg.EnumerateChildren(true).Where(e => e.Name.Contains("Stream")).Count(), 3);
         }
 
         [TestMethod]

--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -108,6 +108,23 @@ namespace OpenMcdf.Test
 
         }
 
+        [TestMethod]
+        public void Test_enumerate()
+        {
+            var cf = new CompoundFile("MultipleStorage.cfs");
+            var stg = cf.RootStorage.GetStorage("MyStorage");
+            
+            bool found = false;
+
+            foreach(var item in stg.EnumerateChildren(false))
+                if (item.Name == "MyStream") found = true;
+            Assert.IsTrue(found);
+
+            found = false;
+            foreach (var item2 in stg.EnumerateChildren(true))
+                if (item2.Name == "AnotherStream") found = true;
+            Assert.IsTrue(found);
+        }
 
         [TestMethod]
         public void Test_TRY_GET_STREAM_STORAGE()


### PR DESCRIPTION
This PR adds an `EnumerateChildren()` method and rewrites `VisitEntries()` to use it in the background.

This allows both enumerate via `foreach` as well as LINQ as wished for in #58.

Examples, adapted from the unit tests:

``` csharp
// total number of storages
stg.EnumerateChildren(true).Where(e => e.IsStorage).Count();
stg.EnumerateChildren(false).Where(e => e.Name.Contains("Stream")).Count();
foreach(var item in stg.EnumerateChildren(false))
                if (item.Name == "MyStream") System.Console.Out.WriteLine(item.Name);
```