### PR TITLE
Fix padding reading in TypedPropertyValue

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -85,7 +85,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     m = (int)size % 4;
 
                     if (m > 0 && !IsVariant)
-                        br.ReadBytes(m); // padding
+                        br.ReadBytes(4 - m); // padding
                     break;
 
                 case PropertyDimensions.IsVector:
@@ -106,7 +106,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
                     m = (int)size % 4;
                     if (m > 0 && !IsVariant)
-                        br.ReadBytes(m); // padding
+                        br.ReadBytes(4 - m); // padding
                     break;
                 default:
                     break;
@@ -134,7 +134,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     m = (int)size % 4;
 
                     if (m > 0 && needsPadding)
-                        for (int i = 0; i < m; i++)  // padding
+                        for (int i = 0; i < 4 - m; i++)  // padding
                             bw.Write((byte)0);
                     break;
 


### PR DESCRIPTION
- E.g. If the start position is 0 and the end position is 13, then `size = 13-0=13`, `m = (int)size % 4=1`, so we don't need `m` bytes of padding, but actually `4`