### PR TITLE
Fix so unallocated directory entries are now spec compliant

### DIFF
--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -2502,7 +2502,7 @@ namespace OpenMcdf
                 throw new CFDisposedException("Compound File closed: cannot access data");
             if (sid < 0)
                 throw new CFException("Invalid SID");
-            Guid g = new Guid("00000000000000000000000000000000");
+            Guid g = Guid.Empty;
             //find first storage containing a non-zero CLSID before SID in directory structure
             for (int i = sid - 1; i >= 0; i--)
             {

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -1631,7 +1631,12 @@ namespace OpenMcdf
             directoryEntries[sid].Parent = null;
             directoryEntries[sid].StgType = StgType.StgInvalid;
             directoryEntries[sid].StartSetc = DirectoryEntry.ZERO;
+            directoryEntries[sid].StorageCLSID = Guid.Empty;
+            directoryEntries[sid].Size = 0;
+            directoryEntries[sid].StateBits = 0;
             directoryEntries[sid].StgColor = StgColor.Red;
+            directoryEntries[sid].CreationDate = new byte[8];
+            directoryEntries[sid].ModifyDate = new byte[8];
         }
 
 

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -1630,6 +1630,8 @@ namespace OpenMcdf
             directoryEntries[sid].Right = null;
             directoryEntries[sid].Parent = null;
             directoryEntries[sid].StgType = StgType.StgInvalid;
+            directoryEntries[sid].StartSetc = DirectoryEntry.ZERO;
+            directoryEntries[sid].StgColor = StgColor.Red;
         }
 
 
@@ -2530,9 +2532,7 @@ namespace OpenMcdf
             if (sid >= directoryEntries.Count)
                 throw new CFException("Invalid SID of the directory entry to remove");
 
-            //Random r = new Random();
-            directoryEntries[sid].SetEntryName("_DELETED_NAME_" + sid.ToString());
-            directoryEntries[sid].StgType = StgType.StgInvalid;
+            ResetDirectoryEntry(sid);
         }
 
         internal void FreeAssociatedData(int sid)

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -60,6 +60,11 @@ namespace OpenMcdf
                 this.StartSetc = ZERO;
             }
 
+            if (stgType == StgType.StgInvalid)
+            {
+                this.StartSetc = ZERO;
+            }
+
             if (name != String.Empty)
             {
                 this.SetEntryName(name);

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -45,6 +45,9 @@ namespace OpenMcdf
         internal static Int32 NOSTREAM
             = unchecked((int)0xFFFFFFFF);
 
+        internal static Int32 ZERO
+            = 0;
+
         private DirectoryEntry(String name, StgType stgType, IList<IDirectoryEntry> dirRepository)
         {
             this.dirRepository = dirRepository;
@@ -54,10 +57,13 @@ namespace OpenMcdf
             if (stgType == StgType.StgStorage)
             {
                 this.creationDate = BitConverter.GetBytes((DateTime.Now.ToFileTime()));
+                this.StartSetc = ZERO;
             }
 
-            this.SetEntryName(name);
-
+            if (name != String.Empty)
+            {
+                this.SetEntryName(name);
+            }
         }
 
         private byte[] entryName = new byte[64];
@@ -86,30 +92,37 @@ namespace OpenMcdf
 
         public void SetEntryName(String entryName)
         {
-            if (
-                entryName.Contains(@"\") ||
-                entryName.Contains(@"/") ||
-                entryName.Contains(@":") ||
-                entryName.Contains(@"!")
+            if (entryName == String.Empty)
+            {
+                this.entryName = new byte[64];
+                this.nameLength = 0;
+            }
+            else
+            {
+                if (
+                    entryName.Contains(@"\") ||
+                    entryName.Contains(@"/") ||
+                    entryName.Contains(@":") ||
+                    entryName.Contains(@"!")
 
-                )
-                throw new CFException("Invalid character in entry: the characters '\\', '/', ':','!' cannot be used in entry name");
+                    )
+                    throw new CFException("Invalid character in entry: the characters '\\', '/', ':','!' cannot be used in entry name");
 
-            if (entryName.Length > 31)
-                throw new CFException("Entry name MUST NOT exceed 31 characters");
+                if (entryName.Length > 31)
+                    throw new CFException("Entry name MUST NOT exceed 31 characters");
 
 
 
-            byte[] newName = null;
-            byte[] temp = Encoding.Unicode.GetBytes(entryName);
-            newName = new byte[64];
-            Buffer.BlockCopy(temp, 0, newName, 0, temp.Length);
-            newName[temp.Length] = 0x00;
-            newName[temp.Length + 1] = 0x00;
+                byte[] newName = null;
+                byte[] temp = Encoding.Unicode.GetBytes(entryName);
+                newName = new byte[64];
+                Buffer.BlockCopy(temp, 0, newName, 0, temp.Length);
+                newName[temp.Length] = 0x00;
+                newName[temp.Length + 1] = 0x00;
 
-            this.entryName = newName;
-            this.nameLength = (ushort)(temp.Length + 2);
-
+                this.entryName = newName;
+                this.nameLength = (ushort)(temp.Length + 2);
+            }
         }
 
         private ushort nameLength;
@@ -137,7 +150,7 @@ namespace OpenMcdf
                 stgType = value;
             }
         }
-        private StgColor stgColor = StgColor.Black;
+        private StgColor stgColor = StgColor.Red;
 
         public StgColor StgColor
         {


### PR DESCRIPTION
See the below quote from the specification:

> Free (unused) directory entries are marked with Object Type 0x0 (unknown or unallocated). **The entire directory entry must consist of all zeroes** except for the child, right sibling, and left sibling pointers, which must be initialized to NOSTREAM (0xFFFFFFFF).

This function:

https://github.com/ironfede/openmcdf/blob/c9d74e2a21cc047d8962032449428fb6ecc45ca4/sources/OpenMcdf/CompoundFile.cs#L1626

Did not reset all required parts it needs to.

Likewise, this:

https://github.com/ironfede/openmcdf/blob/c9d74e2a21cc047d8962032449428fb6ecc45ca4/sources/OpenMcdf/CompoundFile.cs#L2534

was not specifiaction compliant either.