### PR TITLE
Ensure string values are null terminated when writing them

### DIFF
--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using OpenMcdf.Extensions.OLEProperties;
 
 namespace OpenMcdf.Extensions.Test
 {
@@ -127,6 +128,54 @@ namespace OpenMcdf.Extensions.Test
 
         }
 
+        // Modify some document summary information properties, save to a file, and then validate the expected results
+        [TestMethod]
+        public void Test_DOCUMENT_SUMMARY_INFO_MODIFY()
+        {
+            if (File.Exists("test_modify_summary.ppt"))
+                File.Delete("test_modify_summary.ppt");
+
+            // Verify initial properties, and then create a modified document
+            using (CompoundFile cf = new CompoundFile("_Test.ppt"))
+            {
+                var dsiStream = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation");
+                var co = dsiStream.AsOLEPropertiesContainer();
+
+                // The company property should exist but be empty
+                var companyProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_COMPANY");
+                Assert.AreEqual("\0\0\0\0", companyProperty.Value);
+
+                // As a sanity check, check that the value of a property that we don't change remains the same
+                var formatProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_PRESFORMAT");
+                Assert.AreEqual("A4 Paper (210x297 mm)\0\0\0", formatProperty.Value);
+
+                // The manager property shouldn't exist, and we'll add it
+                Assert.IsFalse(co.Properties.Any(prop => prop.PropertyName == "PIDDSI_MANAGER"));
+                var managerProp = co.NewProperty(VTPropertyType.VT_LPSTR, 0x0000000E, "PIDDSI_MANAGER");
+                co.AddProperty(managerProp);
+
+                companyProperty.Value = "My Company";
+                managerProp.Value = "The Boss";
+
+                co.Save(dsiStream);
+                cf.SaveAs(@"test_modify_summary.ppt");
+            }
+
+            using (CompoundFile cf = new CompoundFile("test_modify_summary.ppt"))
+            {
+                var co = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
+
+                var companyProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_COMPANY");
+                Assert.AreEqual("My Company\0", companyProperty.Value);
+
+                var formatProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_PRESFORMAT");
+                Assert.AreEqual("A4 Paper (210x297 mm)\0\0\0", formatProperty.Value);
+
+                var managerProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_MANAGER");
+                Assert.AreEqual("The Boss\0", managerProperty.Value);
+            }
+        }
+
         [TestMethod]
         public void Test_SUMMARY_INFO_READ_UTF8_ISSUE_33()
         {
@@ -240,6 +289,48 @@ namespace OpenMcdf.Extensions.Test
                 cf.Close();
             }
 
+        }
+
+        // Test that we can modify an LPWSTR property, and the value is null terminated as required
+        [TestMethod]
+        public void Test_SUMMARY_INFO_MODIFY_LPWSTRING()
+        {
+            if (File.Exists("test_write_lpwstr.doc"))
+                File.Delete("test_write_lpwstr.doc");
+
+            // Modify some LPWSTR properties, and save to a new file
+            using (CompoundFile cf = new CompoundFile("wstr_presets.doc"))
+            {
+                var dsiStream = cf.RootStorage.GetStream("\u0005SummaryInformation");
+                var co = dsiStream.AsOLEPropertiesContainer();
+
+                var authorProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_AUTHOR");
+                Assert.AreEqual(VTPropertyType.VT_LPWSTR, authorProperty.VTType);
+                Assert.AreEqual("zkyiqpqoroxnbdwhnjfqroxlgylpbgcwuhjfifpkvycugvuecoputqgknnbs\0", authorProperty.Value);
+
+                var keyWordsProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_KEYWORDS");
+                Assert.AreEqual(VTPropertyType.VT_LPWSTR, keyWordsProperty.VTType);
+                Assert.AreEqual("abcdefghijk\0", keyWordsProperty.Value);
+
+                authorProperty.Value = "ABC";
+                keyWordsProperty.Value = "";
+                co.Save(dsiStream);
+                cf.SaveAs("test_write_lpwstr.doc");
+            }
+
+            // Open the new file and check for the expected values
+            using (CompoundFile cf = new CompoundFile("test_write_lpwstr.doc"))
+            {
+                var co = cf.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
+
+                var authorProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_AUTHOR");
+                Assert.AreEqual(VTPropertyType.VT_LPWSTR, authorProperty.VTType);
+                Assert.AreEqual("ABC\0", authorProperty.Value);
+
+                var keyWordsProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_KEYWORDS");
+                Assert.AreEqual(VTPropertyType.VT_LPWSTR, keyWordsProperty.VTType);
+                Assert.AreEqual("\0", keyWordsProperty.Value);
+            }
         }
 
     }


### PR DESCRIPTION
refs #47 

When testing adding or modifying properties, I noticed that new or modified string properties weren't getting null terminated, and that was causing issues with office apps like powerpoint which were showing truncated property values.

I went to add the null values, but it isn't quite that simple as any properties that OpenMxdf has read itself will retain the null terminators from the originating file whereas new values supplied by a user generally won't, so - try to check if the value has a trailing null already and only write an extra one if not.

This *seems* to work, though i'm not 100% sure on the situation with empty strings (The Windows native compound doc apis seem to set a length of 1 and include a null for empty string properties, so I've done the same)