### PR TITLE
Change OpenMcdf.Extensions to use PackageLicenseExpression instead of…

### DIFF
--- a/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
+++ b/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
@@ -59,7 +59,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>2.3.0.1</Version>
-    <PackageLicenseUrl>https://opensource.org/licenses/MPL-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ironfede/openmcdf</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/ironfede/openmcdf</RepositoryUrl>


### PR DESCRIPTION
… (the deprecated) PackageLicenseUrl

An observation whilst testing with some license validation tools - the main package has been changed to use PackageLicenseExpression but the extensions package is still using the deprecated PackageLicenseUrl