### PR TITLE
Tweak the writing of offsets when writing user defined properties

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
@@ -149,11 +149,11 @@ namespace OpenMcdf.Extensions.OLEProperties
 
             var padding0 = bw.BaseStream.Position % 4;
 
-            //if (padding0 > 0)
-            //{
-            //    for (int p = 0; p < padding0; p++)
-            //        bw.Write((byte)0);
-            //}
+            if (padding0 > 0)
+            {
+                for (int p = 0; p < 4 - padding0; p++)
+                    bw.Write((byte)0);
+            }
 
             int size0 = (int)(bw.BaseStream.Position - oc0.OffsetPS);
 
@@ -183,7 +183,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
                 int size1 = (int)(bw.BaseStream.Position - oc1.OffsetPS);
 
-                bw.Seek(oc1.OffsetPS + 4, System.IO.SeekOrigin.Begin);
+                bw.Seek(oc1.OffsetPS, System.IO.SeekOrigin.Begin);
                 bw.Write(size1);
             }
 
@@ -214,8 +214,8 @@ namespace OpenMcdf.Extensions.OLEProperties
             {
                 for (int i = 0; i < PropertySet1.PropertyIdentifierAndOffsets.Count; i++)
                 {
-                    bw.Seek((int)oc1.PropertyIdentifierOffsets[i], System.IO.SeekOrigin.Begin); //Offset of 4 to Offset value
-                    bw.Write(oc1.PropertyOffsets[i] - oc1.OffsetPS);
+                    bw.Seek((int)oc1.PropertyIdentifierOffsets[i] + 4, System.IO.SeekOrigin.Begin); //Offset of 4 to Offset value
+                    bw.Write((int)(oc1.PropertyOffsets[i] - oc1.OffsetPS));
                 }
             }
         }


### PR DESCRIPTION
As per the Microsoft documentation at https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-oshared/fe59ffd9-79e9-44fb-a1c9-2466057b05c6 - 

```
The total size of this property set’s PropertySet structure ([MS-OLEPS] section [2.20](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-OLEPS/aefcbddf-f299-4f5e-a9da-65ce4ca55075)) MUST be padded to a multiple of 4 bytes
```

but the padding code was commented out?
When debugging an attempt at writing the user defined properties, I had a case where the size ended up at 299 bytes when it should really be padded up to 300, and I think this fixes that.

@@NOTE@@ It might need additional padding adding to the end of the user defined section, but the documents I'm testing with are all ending up with the size a multiple of 4 with no padding, so I don't yet have a test for that case.