### PR TITLE
Add the whole 'BenchmarkDotNet.Artifacts' folder to gitignore, rather than jus…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ TestResults/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
-/sources/Test/OpenMcdf.Benchmark/BenchmarkDotNet.Artifacts/OpenMcdf.Benchmark.InMemory-20190412-113734.log
+/sources/Test/OpenMcdf.Benchmark/BenchmarkDotNet.Artifacts


### PR DESCRIPTION
…t one specific log file

I don't think any of this stuff needs to be tracked by Git:

![image](https://github.com/ironfede/openmcdf/assets/1178570/5ea0571b-8e2a-46d4-8539-86084b5e90d2)

?