### PR TITLE
Add a couple of benchmarks for AsOLEPropertiesContainer

### DIFF
--- a/sources/Test/OpenMcdf.Benchmark/Extensions.cs
+++ b/sources/Test/OpenMcdf.Benchmark/Extensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using OpenMcdf.Extensions;
+
+namespace OpenMcdf.Benchmark
+{
+    // Simple benchmarks for reading OLE Properties with OpenMcdf.Extensions.
+    [SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp31)]
+    [MemoryDiagnoser]
+    public class ExtensionsRead
+    {
+        // Keep the Storage as a member, as we're only testing the OLEProperties bits, not the underlying CompoundFile
+        private readonly CompoundFile udTestFile;
+
+        // Load the test file on creation
+        public ExtensionsRead()
+        {
+            string testFile = Path.Combine("TestFiles", "winUnicodeDictionary.doc");
+            this.udTestFile = new CompoundFile(testFile);
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            udTestFile.Close();
+        }
+
+        [Benchmark]
+        public void TestReadSummaryInformation()
+        {
+            this.udTestFile.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
+        }
+
+        [Benchmark]
+        public void TestReadDocumentSummaryInformation()
+        {
+            this.udTestFile.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
+        }
+    }
+}

--- a/sources/Test/OpenMcdf.Benchmark/OpenMcdf.Benchmark.csproj
+++ b/sources/Test/OpenMcdf.Benchmark/OpenMcdf.Benchmark.csproj
@@ -6,11 +6,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OpenMcdf.Extensions\OpenMcdf.Extensions.csproj" />
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestFiles\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\TestFiles\winUnicodeDictionary.doc" Link="TestFiles\winUnicodeDictionary.doc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/sources/Test/OpenMcdf.Benchmark/Program.cs
+++ b/sources/Test/OpenMcdf.Benchmark/Program.cs
@@ -6,7 +6,7 @@ namespace OpenMcdf.Benchmark
     {
         private static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<InMemory>();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }
 }


### PR DESCRIPTION
I just thought it'd be useful to test a few more things whilst looking at other issues, e.g.

```
| Method                             | Mean      | Error    | StdDev   | Gen0    | Gen1   | Allocated |
|----------------------------------- |----------:|---------:|---------:|--------:|-------:|----------:|
| TestReadSummaryInformation         |  71.00 us | 0.761 us | 0.675 us | 18.1885 | 0.2441 | 112.02 KB |
| TestReadDocumentSummaryInformation | 126.58 us | 2.374 us | 4.401 us | 33.9355 | 0.4883 | 209.02 KB |
```