### PR TITLE
[StructuredStorageExplorer] Hide the OLE Properties displays when swi…

### DIFF
--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -90,6 +90,11 @@ namespace StructuredStorageExplorer
 
             propertyGrid1.SelectedObject = null;
             hexEditor.ByteProvider = null;
+
+#if OLE_PROPERTY
+            dgvUserDefinedProperties.DataSource = null;
+            dgvOLEProps.DataSource = null;
+#endif
         }
 
         private bool canUpdate = false;
@@ -424,6 +429,7 @@ namespace StructuredStorageExplorer
                     treeView1.SelectedNode = n;
 
 
+
                     // The tag property contains the underlying CFItem.
                     CFItem target = (CFItem)n.Tag;
 
@@ -435,6 +441,9 @@ namespace StructuredStorageExplorer
                         exportDataToolStripMenuItem.Enabled = true;
 
 #if OLE_PROPERTY
+                        dgvUserDefinedProperties.DataSource = null;
+                        dgvOLEProps.DataSource = null;
+
                         if (target.Name == "\u0005SummaryInformation" || target.Name == "\u0005DocumentSummaryInformation")
                         {
                             OLEPropertiesContainer c = ((CFStream)target).AsOLEPropertiesContainer();
@@ -496,12 +505,6 @@ namespace StructuredStorageExplorer
                                 ds2.AcceptChanges();
                                 dgvUserDefinedProperties.DataSource = ds2;
                             }
-
-
-                        }
-                        else
-                        {
-                            dgvOLEProps.DataSource = null;
                         }
 #endif
                     }


### PR DESCRIPTION
…tching to a stream that has no properties and when closing a file

As it stands, the user defined properties display never gets cleared once shown - maybe on the selection change case it'd be easiest to just hide both properties fields on the selection change, and put back any that are needed afterwards?
![explore](https://github.com/ironfede/openmcdf/assets/1178570/41a24631-5fe5-4cee-bf0a-34b47188b447)

