### PR TITLE
[RFC] Add a .NET 8.0 target to OpenMcdf.Extensions

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -9,7 +9,7 @@ namespace OpenMcdf.Extensions.OLEProperties
     {
         static PropertyFactory()
         {
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         }

--- a/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
+++ b/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net40</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
+    <!-- Mark as trimmable and enable trimming analysis in .NET 6.0+ builds -->
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <!-- Mark as AOT compatible and enable AOT analysis in .NET 8.0+ builds -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->

--- a/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
+++ b/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net6.0</TargetFrameworks>
+    <TargetFrameworks>net45;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
I see from the code history that there was once a change to .NET 6.0, that was then reverted to .NET Standard 2.0.
However, I think it would be useful to add an additional .NET 6.0 target on top of the existing ones (rather than removing them).

The main immediate arguments are:

1. A .NET 6,0 build doesn't need to use the System.Text.Encoding.CodePages NuGet package, as System.Text.Encoding.CodePages is built in to it.
2. In order to enable new features like IsTrimmable and get analysis warnings about any issues. (I've been trying to use it in a self contained, trimmed build recently, and more early analysis is always useful there)

But also it should be useful for #57 to make span based functions in System.IO.Stream and related available, as there are places that should be able to benefit from things like spans, stackalloced buffers etc (e.g. writing null terminators and padding with spans, instead of writing bytes in loops)

This is just doing the Extensions lib now due to the System.Text.Encoding.CodePages dependency, but the same question exists for the core library.

Thoughts?
