### PR TITLE
Fix #121

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
@@ -55,7 +56,13 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         private string GetName()
         {
-            return Encoding.GetEncoding(this.codePage).GetString(nameBytes);
+
+            var result = Encoding.GetEncoding(this.codePage).GetString(nameBytes);
+
+            result = result.Trim('\0');
+
+            return result;
+
         }
 
 

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
@@ -33,10 +33,30 @@ namespace OpenMcdf.Extensions.OLEProperties
             internal set;
         }
 
+        object value;
+
         public object Value
         {
-            get;
-            set;
+            get
+            {
+                switch (VTType)
+                {
+                    case VTPropertyType.VT_LPSTR:
+                    case VTPropertyType.VT_LPWSTR:
+                        if (value is string str && !String.IsNullOrEmpty(str))
+                            return str.Trim('\0');
+                        break;
+                    default:
+                        return this.value;
+
+                }
+
+                return this.value;
+            }
+            set
+            {
+                this.value = value;
+            }
         }
 
         public override bool Equals(object obj)

--- a/sources/OpenMcdf.Extensions/Properties/AssemblyInfo.cs
+++ b/sources/OpenMcdf.Extensions/Properties/AssemblyInfo.cs
@@ -38,4 +38,4 @@ using System.Runtime.InteropServices;
 // http://blog.paranoidcoding.com/2016/04/05/deterministic-builds-in-roslyn.html
 // and Compilers should be deterministic: same inputs generate same outputs
 // https://stackoverflow.com/questions/43019832/auto-versioning-in-visual-studio-2017-net-core/46985624#46985624
-[assembly: AssemblyVersion("2.3.1.0")]
+[assembly: AssemblyVersion("2.3.2.0")]

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -143,14 +143,15 @@ namespace OpenMcdf.Extensions.Test
 
                 // The company property should exist but be empty
                 var companyProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_COMPANY");
-                Assert.AreEqual("\0\0\0\0", companyProperty.Value);
+                Assert.AreEqual("", companyProperty.Value);
 
                 // As a sanity check, check that the value of a property that we don't change remains the same
                 var formatProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_PRESFORMAT");
-                Assert.AreEqual("A4 Paper (210x297 mm)\0\0\0", formatProperty.Value);
+                Assert.AreEqual("A4 Paper (210x297 mm)", formatProperty.Value);
 
                 // The manager property shouldn't exist, and we'll add it
                 Assert.IsFalse(co.Properties.Any(prop => prop.PropertyName == "PIDDSI_MANAGER"));
+
                 var managerProp = co.NewProperty(VTPropertyType.VT_LPSTR, 0x0000000E, "PIDDSI_MANAGER");
                 co.AddProperty(managerProp);
 
@@ -159,6 +160,7 @@ namespace OpenMcdf.Extensions.Test
 
                 co.Save(dsiStream);
                 cf.SaveAs(@"test_modify_summary.ppt");
+                cf.Close() ;
             }
 
             using (CompoundFile cf = new CompoundFile("test_modify_summary.ppt"))
@@ -166,13 +168,13 @@ namespace OpenMcdf.Extensions.Test
                 var co = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
 
                 var companyProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_COMPANY");
-                Assert.AreEqual("My Company\0", companyProperty.Value);
+                Assert.AreEqual("My Company", companyProperty.Value);
 
                 var formatProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_PRESFORMAT");
-                Assert.AreEqual("A4 Paper (210x297 mm)\0\0\0", formatProperty.Value);
+                Assert.AreEqual("A4 Paper (210x297 mm)", formatProperty.Value);
 
                 var managerProperty = co.Properties.First(prop => prop.PropertyName == "PIDDSI_MANAGER");
-                Assert.AreEqual("The Boss\0", managerProperty.Value);
+                Assert.AreEqual("The Boss", managerProperty.Value);
             }
         }
 
@@ -306,11 +308,11 @@ namespace OpenMcdf.Extensions.Test
 
                 var authorProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_AUTHOR");
                 Assert.AreEqual(VTPropertyType.VT_LPWSTR, authorProperty.VTType);
-                Assert.AreEqual("zkyiqpqoroxnbdwhnjfqroxlgylpbgcwuhjfifpkvycugvuecoputqgknnbs\0", authorProperty.Value);
+                Assert.AreEqual("zkyiqpqoroxnbdwhnjfqroxlgylpbgcwuhjfifpkvycugvuecoputqgknnbs", authorProperty.Value);
 
                 var keyWordsProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_KEYWORDS");
                 Assert.AreEqual(VTPropertyType.VT_LPWSTR, keyWordsProperty.VTType);
-                Assert.AreEqual("abcdefghijk\0", keyWordsProperty.Value);
+                Assert.AreEqual("abcdefghijk", keyWordsProperty.Value);
 
                 authorProperty.Value = "ABC";
                 keyWordsProperty.Value = "";
@@ -325,11 +327,11 @@ namespace OpenMcdf.Extensions.Test
 
                 var authorProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_AUTHOR");
                 Assert.AreEqual(VTPropertyType.VT_LPWSTR, authorProperty.VTType);
-                Assert.AreEqual("ABC\0", authorProperty.Value);
+                Assert.AreEqual("ABC", authorProperty.Value);
 
                 var keyWordsProperty = co.Properties.First(prop => prop.PropertyName == "PIDSI_KEYWORDS");
                 Assert.AreEqual(VTPropertyType.VT_LPWSTR, keyWordsProperty.VTType);
-                Assert.AreEqual("\0", keyWordsProperty.Value);
+                Assert.AreEqual("", keyWordsProperty.Value);
             }
         }
 
@@ -359,16 +361,16 @@ namespace OpenMcdf.Extensions.Test
                 Assert.AreEqual((short)1200, propArray[0].Value);
 
                 // String properties
-                Assert.AreEqual("A\0", propArray[1].PropertyName);
-                Assert.AreEqual("\0", propArray[1].Value);
-                Assert.AreEqual("AB\0", propArray[2].PropertyName);
-                Assert.AreEqual("X\0", propArray[2].Value);
-                Assert.AreEqual("ABC\0", propArray[3].PropertyName);
-                Assert.AreEqual("XY\0", propArray[3].Value);
-                Assert.AreEqual("ABCD\0", propArray[4].PropertyName);
-                Assert.AreEqual("XYZ\0", propArray[4].Value);
-                Assert.AreEqual("ABCDE\0", propArray[5].PropertyName);
-                Assert.AreEqual("XYZ!\0", propArray[5].Value);
+                Assert.AreEqual("A", propArray[1].PropertyName);
+                Assert.AreEqual("", propArray[1].Value);
+                Assert.AreEqual("AB", propArray[2].PropertyName);
+                Assert.AreEqual("X", propArray[2].Value);
+                Assert.AreEqual("ABC", propArray[3].PropertyName);
+                Assert.AreEqual("XY", propArray[3].Value);
+                Assert.AreEqual("ABCD", propArray[4].PropertyName);
+                Assert.AreEqual("XYZ", propArray[4].Value);
+                Assert.AreEqual("ABCDE", propArray[5].PropertyName);
+                Assert.AreEqual("XYZ!", propArray[5].Value);
             }
         }
 
@@ -426,16 +428,16 @@ namespace OpenMcdf.Extensions.Test
                 Assert.AreEqual((short)-535, propArray[0].Value);
 
                 // User properties
-                Assert.AreEqual("StringProperty\0", propArray[1].PropertyName);
-                Assert.AreEqual("Hello\0", propArray[1].Value);
+                Assert.AreEqual("StringProperty", propArray[1].PropertyName);
+                Assert.AreEqual("Hello", propArray[1].Value);
                 Assert.AreEqual(VTPropertyType.VT_LPSTR, propArray[1].VTType);
-                Assert.AreEqual("BooleanProperty\0", propArray[2].PropertyName);
+                Assert.AreEqual("BooleanProperty", propArray[2].PropertyName);
                 Assert.AreEqual(true, propArray[2].Value);
                 Assert.AreEqual(VTPropertyType.VT_BOOL, propArray[2].VTType);
-                Assert.AreEqual("IntegerProperty\0", propArray[3].PropertyName);
+                Assert.AreEqual("IntegerProperty", propArray[3].PropertyName);
                 Assert.AreEqual(3456, propArray[3].Value);
                 Assert.AreEqual(VTPropertyType.VT_I4, propArray[3].VTType);
-                Assert.AreEqual("DateProperty\0", propArray[4].PropertyName);
+                Assert.AreEqual("DateProperty", propArray[4].PropertyName);
                 Assert.AreEqual(testNow, propArray[4].Value);
                 Assert.AreEqual(VTPropertyType.VT_FILETIME, propArray[4].VTType);
             }


### PR DESCRIPTION
This pr should fix #121 .
I've partially followed specifications [MS-OLEPS] 
I've chosen not to expose any trailing null char BUT embedded nulls will be left untouched.

As stated in note 1 to section 2.5

```
Windows presents properties with PropertySet VT_LPSTR (0x001E) to applications
as null-terminated string values such that the application cannot reliably detect the presence of
trailing null characters or any characters following the first embedded null character.
```

client application cannot detect trailing nulls after string terminator.

Waiting for some thoughts or comment before merging.

Many thanks,
Federico