### PR TITLE
[POC] Add some Span based write functions to CFStream

### DIFF
--- a/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
+++ b/sources/OpenMcdf.Extensions/OpenMcdf.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/sources/OpenMcdf/CFStream.cs
+++ b/sources/OpenMcdf/CFStream.cs
@@ -42,6 +42,11 @@ namespace OpenMcdf
         /// <remarks>Existing associated data will be lost after method invocation</remarks>
         public void SetData(byte[] data)
         {
+            this.SetData(data.AsSpan());
+        }
+
+        public void SetData(ReadOnlySpan<byte> data)
+        {
             CheckDisposed();
 
             this.CompoundFile.FreeData(this);
@@ -57,7 +62,13 @@ namespace OpenMcdf
         /// its current size</remarks>
         public void Write(byte[] data, long position)
         {
-            this.Write(data, position, 0, data.Length);
+            this.Write(data.AsSpan(), position);
+        }
+
+        public void Write(ReadOnlySpan<byte> buffer, long position)
+        {
+            CheckDisposed();
+            this.CompoundFile.WriteData(this, buffer, position);
         }
 
         /// <summary>
@@ -73,8 +84,7 @@ namespace OpenMcdf
         /// its current size.</remarks>
         internal void Write(byte[] data, long position, int offset, int count)
         {
-            CheckDisposed();
-            this.CompoundFile.WriteData(this, data, position, offset, count);
+            this.Write(data.AsSpan(offset, count), position);
         }
 
         /// <summary>
@@ -101,6 +111,11 @@ namespace OpenMcdf
         /// to simplify its use inside loops.
         /// </remarks>
         public void Append(byte[] data)
+        {
+            this.Append(data.AsSpan());
+        }
+
+        public void Append(ReadOnlySpan<byte> data)
         {
             CheckDisposed();
             if (this.Size > 0)

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -2050,9 +2050,9 @@ namespace OpenMcdf
         /// INTERNAL DEVELOPMENT. DO NOT CALL.
         /// <param name="directoryEntry"></param>
         /// <param name="buffer"></param>
-        internal void AppendData(CFItem cfItem, byte[] buffer)
+        internal void AppendData(CFItem cfItem, ReadOnlySpan<byte> buffer)
         {
-            WriteData(cfItem, cfItem.Size, buffer);
+            WriteData(cfItem, buffer, cfItem.Size);
         }
 
         /// <summary>
@@ -2261,12 +2261,7 @@ namespace OpenMcdf
             }
         }
 
-        internal void WriteData(CFItem cfItem, long position, byte[] buffer)
-        {
-            WriteData(cfItem, buffer, position, 0, buffer.Length);
-        }
-
-        internal void WriteData(CFItem cfItem, byte[] buffer, long position, int offset, int count)
+        internal void WriteData(CFItem cfItem, ReadOnlySpan<byte> buffer, long position)
         {
             if (buffer == null)
                 throw new CFInvalidOperation("Parameter [buffer] cannot be null");
@@ -2277,7 +2272,8 @@ namespace OpenMcdf
             if (buffer.Length == 0) return;
 
             // Get delta size induced by client
-            long delta = position + count - cfItem.Size < 0 ? 0 : position + count - cfItem.Size;
+            int count = buffer.Length;
+            long delta = (position + count) - cfItem.Size < 0 ? 0 : (position + count) - cfItem.Size;
             long newLength = cfItem.Size + delta;
 
             SetStreamLength(cfItem, newLength);
@@ -2296,7 +2292,7 @@ namespace OpenMcdf
             StreamView sv = new StreamView(sectorChain, _sectorSize, newLength, null, sourceStream);
 
             sv.Seek(position, SeekOrigin.Begin);
-            sv.Write(buffer, offset, count);
+            sv.WriteSpan(buffer);
 
             if (cfItem.Size < header.MinSizeStandardStream)
             {
@@ -2305,9 +2301,9 @@ namespace OpenMcdf
             }
         }
 
-        internal void WriteData(CFItem cfItem, byte[] buffer)
+        internal void WriteData(CFItem cfItem, ReadOnlySpan<byte> buffer)
         {
-            WriteData(cfItem, 0, buffer);
+            WriteData(cfItem, buffer, 0);
         }
 
         /// <summary>

--- a/sources/OpenMcdf/OpenMcdf.csproj
+++ b/sources/OpenMcdf/OpenMcdf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net45</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <SignAssembly>true</SignAssembly>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
@@ -111,5 +111,10 @@ It supports read/write operations on streams and storages and traversal of struc
     </Content>
     <None Include="OpenMcdf.snk" />
     <None Include="OpenMcdfClassDiagram.cd" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.5</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
An experiment for #57 to see how much can be added by just rearranging the internal functions, without having to duplicate blocks of code for the array/span cases.

Currently just does the suggested write functionswith minimal surrounding changes - similar things could be done for some of the read functions as well.