### PR TITLE
Is there a need to use Array.CreateInstance(typeof(byte)) to create b…

### DIFF
--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -523,7 +523,7 @@ namespace OpenMcdf
                 CheckForLockSector();
 
             sourceStream.Seek(0, SeekOrigin.Begin);
-            sourceStream.Write((byte[])Array.CreateInstance(typeof(byte), GetSectorSize()), 0, sSize);
+            sourceStream.Write(new byte[sSize], 0, sSize);
 
             CommitDirectory();
 
@@ -2052,7 +2052,7 @@ namespace OpenMcdf
                     }
                 }
 
-                stream.Write((byte[])Array.CreateInstance(typeof(byte), sSize), 0, sSize);
+                stream.Write(new byte[sSize], 0, sSize);
 
                 CommitDirectory();
 


### PR DESCRIPTION
…yte arrays?

I tried building an application that uses OpenMcdf as NativeAOT (.NET 8.0) and got this warning from the compiler:
```
16:07:28:585	3>OpenMcdf.CompoundFile.Commit(Boolean): Using member 'System.Array.CreateInstance(Type,Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
```
I guess the code for byte arrays should always exist given they're used elsewhere, but - I'm not sure if there is a need to use Array.CreateInstance rather than just ```new[]``` anyway?