### PR TITLE
[Test] Store the value of FmtID0 when reading a property set, and use that v…

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -17,6 +17,7 @@ namespace OpenMcdf.Extensions.OLEProperties
         public bool HasUserDefinedProperties { get; private set; }
 
         public ContainerType ContainerType { get; internal set; }
+        private Guid? FmtID0 { get; }
 
         public PropertyContext Context { get; private set; }
 
@@ -100,6 +101,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     break;
             }
 
+            this.FmtID0 = pStream.FMTID0;
 
             this.PropertyNames = (Dictionary<uint, string>)pStream.PropertySet0.Properties
                 .Where(p => p.PropertyType == PropertyType.DictionaryProperty).FirstOrDefault()?.Value;
@@ -238,6 +240,8 @@ namespace OpenMcdf.Extensions.OLEProperties
             Stream s = new StreamDecorator(cfStream);
             BinaryWriter bw = new BinaryWriter(s);
 
+            Guid fmtId0 = this.FmtID0 ?? (this.ContainerType == ContainerType.SummaryInfo ? new Guid(WellKnownFMTID.FMTID_SummaryInformation) : new Guid(WellKnownFMTID.FMTID_DocSummaryInformation));
+
             PropertySetStream ps = new PropertySetStream
             {
                 ByteOrder = 0xFFFE,
@@ -247,7 +251,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
                 NumPropertySets = 1,
 
-                FMTID0 = this.ContainerType == ContainerType.SummaryInfo ? new Guid(WellKnownFMTID.FMTID_SummaryInformation) : new Guid(WellKnownFMTID.FMTID_DocSummaryInformation),
+                FMTID0 = fmtId0,
                 Offset0 = 0,
 
                 FMTID1 = Guid.Empty,


### PR DESCRIPTION
…alue on write if available.

As discussed in #134, writing property sets other than SummaryInformation/DocumentSummaryInformation doesn't work because the FmdID0 always gets set to one of those two on write, so any sets that were deemed ```AppSpecific``` on load get the wrong value written.

Would it be reasonble to avoid that by retaining the existing FmtID0 when reading a stream, and writing the same value back on write? (falling back to the current behaviour if no value is available)?

We could maybe add a constructor that allows an ID to be specified when a brand new OLEPropertiesContainer is created, but that's a public API change so not quite the same.