### PR TITLE
Update Microsoft.NET.Test.Sdk to 17.3.3

### DIFF
--- a/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
+++ b/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>

--- a/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
+++ b/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
@@ -75,7 +75,7 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>


### PR DESCRIPTION
Visual Studio was giving me some warnings about transitive references to test packages with known CVEs, and updating the test SDK to 17.3.3 seems to fix that as it removes a great many old dependencies:
```
Test\OpenMcdf.Test

Uninstalling:

Microsoft.CSharp.4.3.0
Microsoft.Win32.Primitives.4.3.0
NETStandard.Library.1.6.1
runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.native.System.IO.Compression.4.3.0
runtime.native.System.Net.Http.4.3.0
runtime.native.System.Security.Cryptography.Apple.4.3.0
runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple.4.3.0
runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl.4.3.0
System.AppContext.4.3.0
System.Buffers.4.3.0
System.Collections.Concurrent.4.3.0
System.Collections.NonGeneric.4.3.0
System.Collections.Specialized.4.3.0
System.ComponentModel.4.3.0
System.ComponentModel.Primitives.4.3.0
System.ComponentModel.TypeConverter.4.3.0
System.Console.4.3.0
System.Diagnostics.DiagnosticSource.4.3.0
System.Diagnostics.Tools.4.3.0
System.Diagnostics.Tracing.4.3.0
System.Dynamic.Runtime.4.3.0
System.Globalization.Calendars.4.3.0
System.Globalization.Extensions.4.3.0
System.IO.Compression.4.3.0
System.IO.Compression.ZipFile.4.3.0
System.IO.FileSystem.4.3.0
System.IO.FileSystem.Primitives.4.3.0
System.Linq.4.3.0
System.Linq.Expressions.4.3.0
System.Net.Http.4.3.0
System.Net.Primitives.4.3.0
System.Net.Sockets.4.3.0
System.ObjectModel.4.3.0
System.Reflection.Emit.4.3.0
System.Reflection.Emit.ILGeneration.4.3.0
System.Reflection.Emit.Lightweight.4.3.0
System.Reflection.Extensions.4.3.0
System.Reflection.TypeExtensions.4.3.0
System.Runtime.Handles.4.3.0
System.Runtime.InteropServices.4.3.0
System.Runtime.InteropServices.RuntimeInformation.4.3.0
System.Runtime.Numerics.4.3.0
System.Runtime.Serialization.Formatters.4.3.0
System.Runtime.Serialization.Primitives.4.3.0
System.Security.Cryptography.Algorithms.4.3.0
System.Security.Cryptography.Cng.4.3.0
System.Security.Cryptography.Csp.4.3.0
System.Security.Cryptography.Encoding.4.3.0
System.Security.Cryptography.OpenSsl.4.3.0
System.Security.Cryptography.Primitives.4.3.0
System.Security.Cryptography.X509Certificates.4.3.0
System.Text.Encoding.Extensions.4.3.0
System.Text.RegularExpressions.4.3.0
System.Threading.Tasks.Extensions.4.3.0
System.Threading.Timer.4.3.0
System.Xml.ReaderWriter.4.3.0
System.Xml.XDocument.4.3.0
System.Xml.XmlDocument.4.3.0

Updates:

Microsoft.CodeCoverage.17.3.1 -> Microsoft.CodeCoverage.17.3.3
Microsoft.NET.Test.Sdk.17.3.1 -> Microsoft.NET.Test.Sdk.17.3.3
Microsoft.TestPlatform.ObjectModel.17.3.1 -> Microsoft.TestPlatform.ObjectModel.17.3.3
Microsoft.TestPlatform.TestHost.17.3.1 -> Microsoft.TestPlatform.TestHost.17.3.3
Newtonsoft.Json.10.0.3 -> Newtonsoft.Json.13.0.1
```

Note: I didn't try updating it any further than this, as the test project targets .NET 4.5 and newer SDK versions require .NET 4.6.2 or newer.