### PR TITLE
Rework OLEProperties.GetDescription to avoid allocating temporary dictionaries

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
@@ -64,28 +64,24 @@ namespace OpenMcdf.Extensions.OLEProperties
 
     public static class Extensions
     {
-        public static String GetDescription(this uint identifier, ContainerType map, Dictionary<uint, string> customDict = null)
+        public static string GetDescription(this uint identifier, ContainerType map, Dictionary<uint, string> customDict = null)
         {
-            Dictionary<uint, string> NameDictionary = new Dictionary<uint, string>();
+            Dictionary<uint, string> nameDictionary = customDict;
 
-            if (customDict == null)
+            if (nameDictionary is null)
             {
                 switch (map)
                 {
                     case ContainerType.SummaryInfo:
-                        NameDictionary = CommonIdentifiers.PropertyIdentifiersSummaryInfo;
+                        nameDictionary = CommonIdentifiers.PropertyIdentifiersSummaryInfo;
                         break;
                     case ContainerType.DocumentSummaryInfo:
-                        NameDictionary = CommonIdentifiers.PropertyIdentifiersDocumentSummaryInfo;
+                        nameDictionary = CommonIdentifiers.PropertyIdentifiersDocumentSummaryInfo;
                         break;
                 }
             }
-            else
-            {
-                NameDictionary = customDict;
-            }
 
-            if (NameDictionary.TryGetValue(identifier, out string value))
+            if (nameDictionary?.TryGetValue(identifier, out string value) == true)
             {
                 return value;
             }

--- a/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
@@ -85,9 +85,9 @@ namespace OpenMcdf.Extensions.OLEProperties
                 NameDictionary = customDict;
             }
 
-            if (NameDictionary.ContainsKey(identifier))
+            if (NameDictionary.TryGetValue(identifier, out string value))
             {
-                return NameDictionary[identifier];
+                return value;
             }
 
             return "0x" + identifier.ToString("x8");


### PR DESCRIPTION
I don't think there should be a need to allocate a new dictionary on every call here?

Also - use Dictionary.TryGetValue rather than ContainsKey/Indexer - 
refs https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1854