### PR TITLE
Spelling and formatting fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,11 @@ variables:
   buildConfiguration: 'Release'
   libFramework: 'netstandard2.0'
   appFramework: 'net6.0'
-  # pay attention to  slashes
+  # pay attention to slashes
   testsProject:  'sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj'
   extensionTestsProject: 'sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj'
   buildProject: 'sources/OpenMcdf/OpenMcdf.csproj'
-  # without filter it  will timoeout in azure AFTER 60+ min
+  # without filter it will timeout in azure AFTER 60+ min
   testFilter: 'Name!=Test_FIX_BUG_GH_14&Name!=Test_FIX_BUG_GH_15'
 
 steps:

--- a/sources/OpenMcdf.Extensions/CFStreamExtensions.cs
+++ b/sources/OpenMcdf.Extensions/CFStreamExtensions.cs
@@ -25,7 +25,7 @@ namespace OpenMcdf.Extensions
         ///// as a OLE properties Stream.
         ///// </summary>
         ///// <param name="cfStream"></param>
-        ///// <returns>A <see cref="T:OpenMcdf.OLEProperties.PropertySetStream">OLE Propertie stream</see></returns>
+        ///// <returns>A <see cref="T:OpenMcdf.OLEProperties.PropertySetStream">OLE Property Set Stream</see></returns>
         //public static OLEProperties.PropertySetStream AsOLEProperties(this CFStream cfStream)
         //{
         //    var result = new OLEProperties.PropertySetStream();

--- a/sources/OpenMcdf.Extensions/CFStreamExtensions.cs
+++ b/sources/OpenMcdf.Extensions/CFStreamExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
+﻿using System.IO;
 
 namespace OpenMcdf.Extensions
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/Common.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Common.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties

--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
@@ -101,7 +101,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 if (addNullTerminator)
                     byteLength += 2;
 
-                bw.Write((uint)byteLength / 2);
+                bw.Write(byteLength / 2);
                 bw.Write(nameBytes);
 
                 if (addNullTerminator)

--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
@@ -51,7 +51,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
             if (m > 0)
             {
-                for(int i = 0; i < m; i++)
+                for (int i = 0; i < m; i++)
                 {
                     br.ReadByte();
                 }
@@ -69,7 +69,7 @@ namespace OpenMcdf.Extensions.OLEProperties
         public void Write(BinaryWriter bw)
         {
             long curPos = bw.BaseStream.Position;
-            
+
             bw.Write(entries.Count);
 
             foreach (KeyValuePair<uint, string> kv in entries)

--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
@@ -1,5 +1,4 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IBinarySerializable.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IBinarySerializable.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 
 namespace OpenMcdf.Extensions.OLEProperties.Interfaces
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IProperty.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace OpenMcdf.Extensions.OLEProperties.Interfaces
+﻿namespace OpenMcdf.Extensions.OLEProperties.Interfaces
 {
     public interface IProperty : IBinarySerializable
     {

--- a/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/IProperty.cs
@@ -17,6 +17,6 @@ namespace OpenMcdf.Extensions.OLEProperties.Interfaces
         {
             get;
         }
-       
+
     }
 }

--- a/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/ITypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/ITypedPropertyValue.cs
@@ -19,7 +19,7 @@ namespace OpenMcdf.Extensions.OLEProperties.Interfaces
 
         bool IsVariant
         {
-            get; 
+            get;
         }
     }
 }

--- a/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/ITypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/Interfaces/ITypedPropertyValue.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace OpenMcdf.Extensions.OLEProperties.Interfaces
+﻿namespace OpenMcdf.Extensions.OLEProperties.Interfaces
 {
     public interface ITypedPropertyValue : IProperty
     {

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using OpenMcdf.Extensions.OLEProperties.Interfaces;
 
 namespace OpenMcdf.Extensions.OLEProperties

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -157,7 +157,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 var existingPropertyNames = (Dictionary<uint, string>)pStream.PropertySet1.Properties
                     .Where(p => p.PropertyType == PropertyType.DictionaryProperty).FirstOrDefault()?.Value;
 
-                UserDefinedProperties.PropertyNames = existingPropertyNames ?? new Dictionary<uint, string> ();
+                UserDefinedProperties.PropertyNames = existingPropertyNames ?? new Dictionary<uint, string>();
             }
         }
 
@@ -262,7 +262,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 }
             };
 
-            PropertyFactory factory = 
+            PropertyFactory factory =
                 this.ContainerType == ContainerType.DocumentSummaryInfo ? DocumentSummaryInfoPropertyFactory.Instance : DefaultPropertyFactory.Instance;
 
             foreach (var op in this.Properties)

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -120,7 +120,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 var op = new OLEProperty(this)
                 {
                     VTType = p.VTType,
-                    PropertyIdentifier = (uint)pStream.PropertySet0.PropertyIdentifierAndOffsets[i].PropertyIdentifier,
+                    PropertyIdentifier = pStream.PropertySet0.PropertyIdentifierAndOffsets[i].PropertyIdentifier,
                     Value = p.Value
                 };
 
@@ -147,7 +147,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     var op = new OLEProperty(UserDefinedProperties);
 
                     op.VTType = p.VTType;
-                    op.PropertyIdentifier = (uint)pStream.PropertySet1.PropertyIdentifierAndOffsets[i].PropertyIdentifier;
+                    op.PropertyIdentifier = pStream.PropertySet1.PropertyIdentifierAndOffsets[i].PropertyIdentifier;
                     op.Value = p.Value;
 
                     UserDefinedProperties.properties.Add(op);

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenMcdf.Extensions.OLEProperties.Interfaces;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
@@ -1,7 +1,5 @@
 ﻿
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -1,7 +1,7 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
 using System;
-using System.Text;
 using System.IO;
+using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -443,7 +443,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     //if (addNullTerminator)
                     dataLength += 2;            // null terminator \u+0000
 
-                   // var mod = dataLength % 4;       // pad to multiple of 4 bytes
+                    // var mod = dataLength % 4;       // pad to multiple of 4 bytes
 
                     bw.Write(dataLength);           // datalength of string + null char (unicode)
                     bw.Write(data);                 // string
@@ -761,7 +761,7 @@ namespace OpenMcdf.Extensions.OLEProperties
     }
 
     // The default property factory.
-    internal sealed class DefaultPropertyFactory : PropertyFactory 
+    internal sealed class DefaultPropertyFactory : PropertyFactory
     {
         public static PropertyFactory Instance { get; } = new DefaultPropertyFactory();
     }

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -602,7 +602,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
             public override void WriteScalarValue(BinaryWriter bw, Decimal pValue)
             {
-                int[] parts = Decimal.GetBits((Decimal)pValue);
+                int[] parts = Decimal.GetBits(pValue);
 
                 bool sign = (parts[3] & 0x80000000) != 0;
                 byte scale = (byte)((parts[3] >> 16) & 0x7F);
@@ -628,14 +628,14 @@ namespace OpenMcdf.Extensions.OLEProperties
             public override bool ReadScalarValue(System.IO.BinaryReader br)
             {
 
-                this.propertyValue = br.ReadUInt16() == (ushort)0xFFFF ? true : false;
+                this.propertyValue = br.ReadUInt16() == 0xFFFF ? true : false;
                 return (bool)propertyValue;
                 //br.ReadUInt16();//padding
             }
 
             public override void WriteScalarValue(BinaryWriter bw, bool pValue)
             {
-                bw.Write((bool)pValue ? (ushort)0xFFFF : (ushort)0);
+                bw.Write(pValue ? (ushort)0xFFFF : (ushort)0);
 
             }
 

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyIdentifierAndOffset.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyIdentifierAndOffset.cs
@@ -1,8 +1,5 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyIdentifierAndOffset.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyIdentifierAndOffset.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {
-    public class PropertyIdentifierAndOffset: IBinarySerializable
+    public class PropertyIdentifierAndOffset : IBinarySerializable
     {
         public uint PropertyIdentifier { get; set; }
         public uint Offset { get; set; }

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyReader.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyReader.cs
@@ -27,8 +27,8 @@
 //            this.ctx.CodePage = (int)(ushort)(short)pr.Value;
 //        }
 
-      
 
-       
+
+
 //    }
 //}

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {
-    internal class PropertySet
+    internal sealed class PropertySet
     {
 
         public PropertyContext PropertyContext

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -12,7 +12,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         public PropertyContext PropertyContext
         {
-            get;  set;
+            get; set;
         }
 
         public uint Size { get; set; }

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -49,7 +49,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
             VTPropertyType vType = (VTPropertyType)br.ReadUInt16();
             br.ReadUInt16(); // Ushort Padding
-            PropertyContext.CodePage = (int)(ushort)br.ReadInt16();
+            PropertyContext.CodePage = (ushort)br.ReadInt16();
 
             br.BaseStream.Position = currPos;
         }

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -1,7 +1,5 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Linq;
 using System.IO;
 

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -1,7 +1,7 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {
-    internal class PropertySetStream
+    internal sealed class PropertySetStream
     {
 
 

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
@@ -1,8 +1,6 @@
 ﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Linq;
 using System.IO;
 
 namespace OpenMcdf.Extensions.OLEProperties

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySetStream.cs
@@ -66,13 +66,13 @@ namespace OpenMcdf.Extensions.OLEProperties
             // Read properties (P0)
             for (int i = 0; i < PropertySet0.NumProperties; i++)
             {
-                br.BaseStream.Seek(Offset0 + PropertySet0.PropertyIdentifierAndOffsets[i].Offset, System.IO.SeekOrigin.Begin);
+                br.BaseStream.Seek(Offset0 + PropertySet0.PropertyIdentifierAndOffsets[i].Offset, SeekOrigin.Begin);
                 PropertySet0.Properties.Add(ReadProperty(PropertySet0.PropertyIdentifierAndOffsets[i].PropertyIdentifier, PropertySet0.PropertyContext.CodePage, br, factory));
             }
 
             if (NumPropertySets == 2)
             {
-                br.BaseStream.Seek(Offset1, System.IO.SeekOrigin.Begin);
+                br.BaseStream.Seek(Offset1, SeekOrigin.Begin);
                 PropertySet1 = new PropertySet();
                 PropertySet1.Size = br.ReadUInt32();
                 PropertySet1.NumProperties = br.ReadUInt32();
@@ -91,7 +91,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 // Read properties
                 for (int i = 0; i < PropertySet1.NumProperties; i++)
                 {
-                    br.BaseStream.Seek(Offset1 + PropertySet1.PropertyIdentifierAndOffsets[i].Offset, System.IO.SeekOrigin.Begin);
+                    br.BaseStream.Seek(Offset1 + PropertySet1.PropertyIdentifierAndOffsets[i].Offset, SeekOrigin.Begin);
                     PropertySet1.Properties.Add(ReadProperty(PropertySet1.PropertyIdentifierAndOffsets[i].PropertyIdentifier, PropertySet1.PropertyContext.CodePage, br, DefaultPropertyFactory.Instance));
                 }
             }
@@ -184,20 +184,20 @@ namespace OpenMcdf.Extensions.OLEProperties
 
                 int size1 = (int)(bw.BaseStream.Position - oc1.OffsetPS);
 
-                bw.Seek(oc1.OffsetPS, System.IO.SeekOrigin.Begin);
+                bw.Seek(oc1.OffsetPS, SeekOrigin.Begin);
                 bw.Write(size1);
             }
 
-            bw.Seek(oc0.OffsetPS, System.IO.SeekOrigin.Begin);
+            bw.Seek(oc0.OffsetPS, SeekOrigin.Begin);
             bw.Write(size0);
 
             int shiftO1 = 2 + 2 + 4 + 16 + 4 + 16; //OFFSET0
-            bw.Seek(shiftO1, System.IO.SeekOrigin.Begin);
+            bw.Seek(shiftO1, SeekOrigin.Begin);
             bw.Write(oc0.OffsetPS);
 
             if (NumPropertySets == 2)
             {
-                bw.Seek(shiftO1 + 4 + 16, System.IO.SeekOrigin.Begin);
+                bw.Seek(shiftO1 + 4 + 16, SeekOrigin.Begin);
                 bw.Write(oc1.OffsetPS);
             }
 
@@ -205,7 +205,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
             for (int i = 0; i < PropertySet0.PropertyIdentifierAndOffsets.Count; i++)
             {
-                bw.Seek((int)oc0.PropertyIdentifierOffsets[i] + 4, System.IO.SeekOrigin.Begin); //Offset of 4 to Offset value
+                bw.Seek((int)oc0.PropertyIdentifierOffsets[i] + 4, SeekOrigin.Begin); //Offset of 4 to Offset value
                 bw.Write((int)(oc0.PropertyOffsets[i] - oc0.OffsetPS));
             }
 
@@ -215,7 +215,7 @@ namespace OpenMcdf.Extensions.OLEProperties
             {
                 for (int i = 0; i < PropertySet1.PropertyIdentifierAndOffsets.Count; i++)
                 {
-                    bw.Seek((int)oc1.PropertyIdentifierOffsets[i] + 4, System.IO.SeekOrigin.Begin); //Offset of 4 to Offset value
+                    bw.Seek((int)oc1.PropertyIdentifierOffsets[i] + 4, SeekOrigin.Begin); //Offset of 4 to Offset value
                     bw.Write((int)(oc1.PropertyOffsets[i] - oc1.OffsetPS));
                 }
             }

--- a/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/ProperyIdentifiers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using OpenMcdf.Extensions.OLEProperties.Interfaces;
+using System.Collections.Generic;
 using System.IO;
-using OpenMcdf.Extensions.OLEProperties.Interfaces;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -79,7 +79,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                         this.propertyValue = ReadScalarValue(br);
                         int size = (int)(br.BaseStream.Position - currentPos);
 
-                        int m = (int)size % 4;
+                        int m = size % 4;
 
                         if (m > 0 && this.NeedsPadding)
                             br.ReadBytes(4 - m); // padding
@@ -103,7 +103,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                             // The padding in a vector can be per-item
                             int itemSize = (int)(br.BaseStream.Position - currentPos);
 
-                            int pad = (int)itemSize % 4;
+                            int pad = itemSize % 4;
                             if (pad > 0 && this.NeedsPadding)
                                 br.ReadBytes(4 - pad); // padding
                         }
@@ -111,7 +111,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                         this.propertyValue = res;
                         int size = (int)(br.BaseStream.Position - currentPos);
 
-                        int m = (int)size % 4;
+                        int m = size % 4;
                         if (m > 0 && this.NeedsPadding)
                             br.ReadBytes(4 - m); // padding
                     }
@@ -138,7 +138,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
                     WriteScalarValue(bw, (T)this.propertyValue);
                     size = (int)(bw.BaseStream.Position - currentPos);
-                    m = (int)size % 4;
+                    m = size % 4;
 
                     if (m > 0 && this.NeedsPadding)
                         for (int i = 0; i < 4 - m; i++)  // padding
@@ -156,7 +156,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                         WriteScalarValue(bw, ((List<T>)this.propertyValue)[i]);
 
                         size = (int)(bw.BaseStream.Position - currentPos);
-                        m = (int)size % 4;
+                        m = size % 4;
 
                         if (m > 0 && this.NeedsPadding)
                             for (int q = 0; q < 4 - m; q++)  // padding
@@ -164,7 +164,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                     }
 
                     size = (int)(bw.BaseStream.Position - currentPos);
-                    m = (int)size % 4;
+                    m = size % 4;
 
                     if (m > 0 && this.NeedsPadding)
                         for (int i = 0; i < 4 - m; i++)  // padding

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using OpenMcdf.Extensions.OLEProperties.Interfaces;
-using System.Linq;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {

--- a/sources/OpenMcdf.Extensions/OLEProperties/VTPropertyType.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/VTPropertyType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace OpenMcdf.Extensions.OLEProperties
+﻿namespace OpenMcdf.Extensions.OLEProperties
 {
     public enum VTPropertyType : ushort
     {

--- a/sources/OpenMcdf.Extensions/OLEProperties/VTPropertyType.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/VTPropertyType.cs
@@ -37,8 +37,8 @@ namespace OpenMcdf.Extensions.OLEProperties
         VT_BLOB_OBJECT = 0x0046, //MUST be a BLOB. 
         VT_CF = 0x0047,         //MUST be a ClipboardData. 
         VT_CLSID = 0x0048,       //MUST be a GUID (Packet Version)
-        VT_VERSIONED_STREAM = 0x0049,       //MUST be a Verisoned Stream, NOT allowed in simple property
-        VT_VECTOR_HEADER  =0x1000,  //--- NOT NORMATIVE
+        VT_VERSIONED_STREAM = 0x0049,       // MUST be a versioned Stream, NOT allowed in simple property
+        VT_VECTOR_HEADER = 0x1000,  //--- NOT NORMATIVE
         VT_ARRAY_HEADER = 0x2000,  //--- NOT NORMATIVE
         VT_VARIANT_VECTOR = 0x000C,//--- NOT NORMATIVE
         VT_VARIANT_ARRAY = 0x200C,//--- NOT NORMATIVE

--- a/sources/OpenMcdf.Extensions/OLEProperties/VTVectorHeader.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/VTVectorHeader.cs
@@ -5,5 +5,5 @@ using System.Text;
 
 namespace OpenMcdf.Extensions.OLEProperties
 {
-    
+
 }

--- a/sources/OpenMcdf.Extensions/OLEProperties/VTVectorHeader.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/VTVectorHeader.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-
-namespace OpenMcdf.Extensions.OLEProperties
+﻿namespace OpenMcdf.Extensions.OLEProperties
 {
 
 }

--- a/sources/OpenMcdf.Extensions/OlePropertiesExtensions.cs
+++ b/sources/OpenMcdf.Extensions/OlePropertiesExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using OpenMcdf.Extensions.OLEProperties;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace OpenMcdf.Extensions
 {

--- a/sources/OpenMcdf.Extensions/Properties/AssemblyInfo.cs
+++ b/sources/OpenMcdf.Extensions/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/OpenMcdf/CFException.cs
+++ b/sources/OpenMcdf/CFException.cs
@@ -141,8 +141,8 @@ namespace OpenMcdf
     [Serializable]
     public class CFInvalidOperation : CFException
     {
-         public CFInvalidOperation()
-            : base()
+        public CFInvalidOperation()
+           : base()
         {
         }
 

--- a/sources/OpenMcdf/CFItem.cs
+++ b/sources/OpenMcdf/CFItem.cs
@@ -92,7 +92,7 @@ namespace OpenMcdf
         public static bool operator ==(CFItem leftItem, CFItem rightItem)
         {
             // If both are null, or both are same instance, return true.
-            if (System.Object.ReferenceEquals(leftItem, rightItem))
+            if (ReferenceEquals(leftItem, rightItem))
             {
                 return true;
             }

--- a/sources/OpenMcdf/CFItem.cs
+++ b/sources/OpenMcdf/CFItem.cs
@@ -138,7 +138,7 @@ namespace OpenMcdf
                     return String.Empty;
             }
 
-            
+
         }
 
         /// <summary>

--- a/sources/OpenMcdf/CFItem.cs
+++ b/sources/OpenMcdf/CFItem.cs
@@ -143,7 +143,7 @@ namespace OpenMcdf
 
         /// <summary>
         /// Size in bytes of the item. It has a valid value 
-        /// only if entity is a stream, otherwise it is setted to zero.
+        /// only if entity is a stream, otherwise it is set to zero.
         /// </summary>
         public long Size
         {

--- a/sources/OpenMcdf/CFStorage.cs
+++ b/sources/OpenMcdf/CFStorage.cs
@@ -7,9 +7,9 @@
  * The Initial Developer of the Original Code is Federico Blaseotto.*/
 
 
+using RedBlackTree;
 using System;
 using System.Collections.Generic;
-using RedBlackTree;
 
 
 namespace OpenMcdf

--- a/sources/OpenMcdf/CFStorage.cs
+++ b/sources/OpenMcdf/CFStorage.cs
@@ -81,7 +81,7 @@ namespace OpenMcdf
             : base(compFile)
         {
             if (dirEntry == null || dirEntry.SID < 0)
-                throw new CFException("Attempting to create a CFStorage using an unitialized directory");
+                throw new CFException("Attempting to create a CFStorage using an uninitialized directory");
 
             this.DirEntry = dirEntry;
         }

--- a/sources/OpenMcdf/CFStream.cs
+++ b/sources/OpenMcdf/CFStream.cs
@@ -25,8 +25,8 @@ namespace OpenMcdf
             : base(compoundFile)
         {
             if (dirEntry == null || dirEntry.SID < 0)
-                throw new CFException("Attempting to add a CFStream using an unitialized directory");
-            
+                throw new CFException("Attempting to add a CFStream using an uninitialized directory");
+
             this.DirEntry = dirEntry;
         }
 

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -484,12 +484,12 @@ namespace OpenMcdf
                 //Here sectors should not be loaded dynamically because
                 //if they are null it means that no change has involved them;
 
-                Sector s = (Sector)sectors[i];
+                Sector s = sectors[i];
 
                 if (s != null && s.DirtyFlag)
                 {
                     if (gap)
-                        sourceStream.Seek((long)((long)(sSize) + (long)i * (long)sSize), SeekOrigin.Begin);
+                        sourceStream.Seek(sSize + i * (long)sSize, SeekOrigin.Begin);
 
                     sourceStream.Write(s.GetData(), 0, sSize);
                     sourceStream.Flush();
@@ -644,7 +644,7 @@ namespace OpenMcdf
                     ValidateHeader(header);
                 }
 
-                int n_sector = Ceiling(((double)(stream.Length - GetSectorSize()) / (double)GetSectorSize()));
+                int n_sector = Ceiling(((stream.Length - GetSectorSize()) / (double)GetSectorSize()));
 
                 if (stream.Length > 0x7FFFFF0)
                     this._transactionLockAllocated = true;
@@ -1273,7 +1273,7 @@ namespace OpenMcdf
             {
                 validationCount = (int)header.DIFATSectorsNumber;
 
-                Sector s = sectors[header.FirstDIFATSectorID] as Sector;
+                Sector s = sectors[header.FirstDIFATSectorID];
 
                 if (s == null) //Lazy loading
                 {
@@ -1307,7 +1307,7 @@ namespace OpenMcdf
                             throw new CFCorruptedFileException("DIFAT sectors count mismatched. Corrupted compound file");
                     }
 
-                    s = sectors[nextSecID] as Sector;
+                    s = sectors[nextSecID];
 
                     if (s == null)
                     {
@@ -1358,7 +1358,7 @@ namespace OpenMcdf
             while (idx < header.FATSectorsNumber && idx < N_HEADER_FAT_ENTRY)
             {
                 nextSecID = header.DIFAT[idx];
-                Sector s = sectors[nextSecID] as Sector;
+                Sector s = sectors[nextSecID];
 
                 if (s == null)
                 {
@@ -1402,7 +1402,7 @@ namespace OpenMcdf
 
                     EnsureUniqueSectorIndex(nextSecID, processedSectors);
 
-                    Sector s = sectors[nextSecID] as Sector;
+                    Sector s = sectors[nextSecID];
 
                     if (s == null)
                     {
@@ -1465,7 +1465,7 @@ namespace OpenMcdf
                 if (nextSecID >= sectors.Count)
                     throw new CFCorruptedFileException(String.Format("Next Sector ID reference an out of range sector. NextID : {0} while sector count {1}", nextSecID, sectors.Count));
 
-                Sector s = sectors[nextSecID] as Sector;
+                Sector s = sectors[nextSecID];
                 if (s == null)
                 {
                     s = new Sector(GetSectorSize(), sourceStream);
@@ -1604,7 +1604,7 @@ namespace OpenMcdf
         {
             get
             {
-                return rootStorage as CFStorage;
+                return rootStorage;
             }
         }
 
@@ -2019,7 +2019,7 @@ namespace OpenMcdf
 
                 for (int i = 0; i < sectors.Count; i++)
                 {
-                    Sector s = sectors[i] as Sector;
+                    Sector s = sectors[i];
 
                     if (s == null)
                     {
@@ -2083,7 +2083,7 @@ namespace OpenMcdf
 
                         }
 
-                        freeList.Enqueue(sectors[idx] as Sector);
+                        freeList.Enqueue(sectors[idx]);
                     }
 
                     idx++;
@@ -2421,7 +2421,7 @@ namespace OpenMcdf
 
             IDirectoryEntry de = cFStream.DirEntry;
 
-            count = (int)Math.Min((long)(de.Size - position), (long)count);
+            count = (int)Math.Min(de.Size - position, count);
 
             StreamView sView = null;
 
@@ -2449,7 +2449,7 @@ namespace OpenMcdf
 
             IDirectoryEntry de = cFStream.DirEntry;
 
-            count = (int)Math.Min((long)(buffer.Length - offset), (long)count);
+            count = (int)Math.Min(buffer.Length - offset, (long)count);
 
             StreamView sView = null;
 
@@ -2776,7 +2776,7 @@ namespace OpenMcdf
             {
                 if (id.GetEntryName() == entryName && id.StgType != StgType.StgInvalid)
                 {
-                    CFItem i = id.StgType == StgType.StgStorage ? (CFItem)new CFStorage(this, id) : (CFItem)new CFStream(this, id);
+                    CFItem i = id.StgType == StgType.StgStorage ? new CFStorage(this, id) : (CFItem)new CFStream(this, id);
                     result.Add(i);
                 }
             }
@@ -2934,13 +2934,13 @@ namespace OpenMcdf
                     if (item.IsStream)
                     {
                         CFStream itemAsStream = item as CFStream;
-                        CFStream st = ((CFStorage)currDstStorage).AddStream(itemAsStream.Name);
+                        CFStream st = currDstStorage.AddStream(itemAsStream.Name);
                         st.SetData(itemAsStream.GetData());
                     }
                     else if (item.IsStorage)
                     {
                         CFStorage itemAsStorage = item as CFStorage;
-                        CFStorage strg = ((CFStorage)currDstStorage).AddStorage(itemAsStorage.Name);
+                        CFStorage strg = currDstStorage.AddStorage(itemAsStorage.Name);
                         strg.CLSID = new Guid(itemAsStorage.CLSID.ToByteArray());
                         DoCompression(itemAsStorage, strg); // recursion, one level deeper
                     }

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -8,10 +8,10 @@
 
 #define FLAT_WRITE // No optimization on the number of write operations
 
+using RedBlackTree;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using RedBlackTree;
 
 namespace OpenMcdf
 {

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -272,12 +272,12 @@ namespace OpenMcdf
         public CompoundFile(CFSVersion cfsVersion, CFSConfiguration configFlags)
         {
             SetConfigurationOptions(configFlags);
-            
+
             this.header = new Header((ushort)cfsVersion);
 
             if (cfsVersion == CFSVersion.Ver_4)
                 this.sectors.OnVer3SizeLimitReached += new Ver3SizeLimitReached(OnSizeLimitReached);
-            
+
             DIFAT_SECTOR_FAT_ENTRIES_COUNT = (GetSectorSize() / 4) - 1;
             FAT_SECTOR_ENTRIES_COUNT = (GetSectorSize() / 4);
 
@@ -353,7 +353,7 @@ namespace OpenMcdf
             DIFAT_SECTOR_FAT_ENTRIES_COUNT = (GetSectorSize() / 4) - 1;
             FAT_SECTOR_ENTRIES_COUNT = (GetSectorSize() / 4);
         }
-        
+
         /// <summary>
         /// Load an existing compound file.
         /// </summary>

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -29,7 +29,7 @@ namespace OpenMcdf
     /// <summary>
     /// Configuration parameters for the compound files.
     /// They can be OR-combined to configure 
-    /// <see cref="T:OpenMcdf.CompoundFile">Compound file</see> behaviour.
+    /// <see cref="T:OpenMcdf.CompoundFile">Compound file</see> behavior.
     /// All flags are NOT set by Default.
     /// </summary>
     [Flags]
@@ -775,7 +775,7 @@ namespace OpenMcdf
                 if (s.Id == -1)
                     throw new CFException("Invalid minisector index");
 
-                // Ministream sectors already allocated
+                // MiniStream sectors already allocated
                 miniStreamView.Seek(Sector.MINISECTOR_SIZE * s.Id, SeekOrigin.Begin);
                 miniStreamView.Write(s.GetData(), 0, Sector.MINISECTOR_SIZE);
             }
@@ -1732,7 +1732,7 @@ namespace OpenMcdf
             {
 
 
-                // If there're more left siblings load them...
+                // If there are more left siblings load them...
                 DoLoadSiblings(bst, directoryEntries[de.LeftSibling]);
                 //NullifyChildNodes(directoryEntries[de.LeftSibling]);
             }
@@ -1741,7 +1741,7 @@ namespace OpenMcdf
             {
                 levelSIDs.Add(de.RightSibling);
 
-                // If there're more right siblings load them...
+                // If there are more right siblings load them...
                 DoLoadSiblings(bst, directoryEntries[de.RightSibling]);
                 //NullifyChildNodes(directoryEntries[de.RightSibling]);
             }
@@ -1753,7 +1753,7 @@ namespace OpenMcdf
             {
                 levelSIDs.Add(de.LeftSibling);
 
-                // If there're more left siblings load them...
+                // If there are more left siblings load them...
                 DoLoadSiblings(bst, directoryEntries[de.LeftSibling]);
             }
 
@@ -1761,7 +1761,7 @@ namespace OpenMcdf
             {
                 levelSIDs.Add(de.RightSibling);
 
-                // If there're more right siblings load them...
+                // If there are more right siblings load them...
                 DoLoadSiblings(bst, directoryEntries[de.RightSibling]);
             }
 
@@ -2291,7 +2291,7 @@ namespace OpenMcdf
                 //Set up destination chain
                 AllocateMiniSectorChain(destSv.BaseSectorChain);
 
-                // Persist to normal strea
+                // Persist to normal stream
                 PersistMiniStreamToStream(destSv.BaseSectorChain);
 
                 //Update dir item

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -15,7 +15,7 @@ using System.IO;
 
 namespace OpenMcdf
 {
-    internal class CFItemComparer : IComparer<CFItem>
+    internal sealed class CFItemComparer : IComparer<CFItem>
     {
         public int Compare(CFItem x, CFItem y)
         {

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -8,8 +8,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.IO;
+using System.Text;
 
 namespace OpenMcdf
 {

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -433,16 +433,16 @@ namespace OpenMcdf
         {
             get
             {
-                if (leftSibling == DirectoryEntry.NOSTREAM)
+                if (leftSibling == NOSTREAM)
                     return null;
 
                 return dirRepository[leftSibling];
             }
             set
             {
-                leftSibling = value != null ? ((IDirectoryEntry)value).SID : DirectoryEntry.NOSTREAM;
+                leftSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
 
-                if (leftSibling != DirectoryEntry.NOSTREAM)
+                if (leftSibling != NOSTREAM)
                     dirRepository[leftSibling].Parent = this;
             }
         }
@@ -451,7 +451,7 @@ namespace OpenMcdf
         {
             get
             {
-                if (rightSibling == DirectoryEntry.NOSTREAM)
+                if (rightSibling == NOSTREAM)
                     return null;
 
                 return dirRepository[rightSibling];
@@ -459,9 +459,9 @@ namespace OpenMcdf
             set
             {
 
-                rightSibling = value != null ? ((IDirectoryEntry)value).SID : DirectoryEntry.NOSTREAM;
+                rightSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
 
-                if (rightSibling != DirectoryEntry.NOSTREAM)
+                if (rightSibling != NOSTREAM)
                     dirRepository[rightSibling].Parent = this;
 
             }

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -29,7 +29,7 @@ namespace OpenMcdf
         Black = 1
     }
 
-    internal class DirectoryEntry : IDirectoryEntry
+    internal sealed class DirectoryEntry : IDirectoryEntry
     {
         internal const int THIS_IS_GREATER = 1;
         internal const int OTHER_IS_GREATER = -1;

--- a/sources/OpenMcdf/Header.cs
+++ b/sources/OpenMcdf/Header.cs
@@ -63,7 +63,7 @@ namespace OpenMcdf
         public ushort SectorShift
         {
             get { return sectorShift; }
-            
+
         }
 
         //32 2 Size of a short-sector in the short-stream container stream (➜6.1) in power-of-two (sssz),

--- a/sources/OpenMcdf/Header.cs
+++ b/sources/OpenMcdf/Header.cs
@@ -11,7 +11,7 @@ using System.IO;
 
 namespace OpenMcdf
 {
-    internal class Header
+    internal sealed class Header
     {
         //0 8 Compound document file identifier: D0H CFH 11H E0H A1H B1H 1AH E1H
         private byte[] headerSignature

--- a/sources/OpenMcdf/Properties/AssemblyInfo.cs
+++ b/sources/OpenMcdf/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 #if ASSERT
 using System.Diagnostics;

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -101,7 +101,7 @@ namespace OpenMcdf
 
                 if (IsStreamed)
                 {
-                    stream.Seek((long)size + (long)this.id * (long)size, SeekOrigin.Begin);
+                    stream.Seek(size + id * (long)size, SeekOrigin.Begin);
                     stream.Read(data, 0, size);
                 }
             }

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -150,7 +150,7 @@ namespace OpenMcdf
 
         /// <summary>
         /// When called from user code, release all resources, otherwise, in the case runtime called it,
-        /// only unmanagd resources are released.
+        /// only unmanaged resources are released.
         /// </summary>
         /// <param name="disposing">If true, method has been called from User code, if false it's been called from .net runtime</param>
         protected virtual void Dispose(bool disposing)

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -18,7 +18,7 @@ namespace OpenMcdf
         Normal, Mini, FAT, DIFAT, RangeLockSector, Directory
     }
 
-    internal class Sector : IDisposable
+    internal sealed class Sector : IDisposable
     {
         public static int MINISECTOR_SIZE = 64;
 
@@ -148,12 +148,11 @@ namespace OpenMcdf
 
         private object lockObject = new Object();
 
-        /// <summary>
-        /// When called from user code, release all resources, otherwise, in the case runtime called it,
-        /// only unmanaged resources are released.
-        /// </summary>
-        /// <param name="disposing">If true, method has been called from User code, if false it's been called from .net runtime</param>
-        protected virtual void Dispose(bool disposing)
+        #region IDisposable Members
+
+        private bool _disposed;//false
+
+        void IDisposable.Dispose()
         {
             try
             {
@@ -161,18 +160,10 @@ namespace OpenMcdf
                 {
                     lock (lockObject)
                     {
-                        if (disposing)
-                        {
-                            // Call from user code...
-
-
-                        }
-
                         this.data = null;
                         this.dirtyFlag = false;
                         this.id = ENDOFCHAIN;
                         this.size = 0;
-
                     }
                 }
             }
@@ -180,17 +171,6 @@ namespace OpenMcdf
             {
                 _disposed = true;
             }
-
-        }
-
-        #region IDisposable Members
-
-        private bool _disposed;//false
-
-        void IDisposable.Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -134,7 +134,7 @@ namespace OpenMcdf
         public void InitFATData()
         {
             data = new byte[size];
-            
+
             for (int i = 0; i < size; i++)
                 data[i] = 0xFF;
 

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -170,7 +170,7 @@ namespace OpenMcdf
 
                         this.data = null;
                         this.dirtyFlag = false;
-                        this.id = Sector.ENDOFCHAIN;
+                        this.id = ENDOFCHAIN;
                         this.size = 0;
 
                     }

--- a/sources/OpenMcdf/SectorCollection.cs
+++ b/sources/OpenMcdf/SectorCollection.cs
@@ -23,7 +23,7 @@ namespace OpenMcdf
     /// large array that may create some problem to GC collection 
     /// (see http://www.simple-talk.com/dotnet/.net-framework/the-dangers-of-the-large-object-heap/ )
     /// </summary>
-    internal class SectorCollection : IList<Sector>
+    internal sealed class SectorCollection : IList<Sector>
     {
         private const int MAX_SECTOR_V4_COUNT_LOCK_RANGE = 524287; //0x7FFFFF00 for Version 4
         private const int SLICE_SIZE = 4096;

--- a/sources/OpenMcdf/SectorCollection.cs
+++ b/sources/OpenMcdf/SectorCollection.cs
@@ -7,7 +7,6 @@
  * The Initial Developer of the Original Code is Federico Blaseotto.*/
 
 using System;
-using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 

--- a/sources/OpenMcdf/StreamRW.cs
+++ b/sources/OpenMcdf/StreamRW.cs
@@ -10,7 +10,7 @@ using System.IO;
 
 namespace OpenMcdf
 {
-    internal class StreamRW
+    internal sealed class StreamRW
     {
         private byte[] buffer = new byte[8];
         private Stream stream;

--- a/sources/OpenMcdf/StreamRW.cs
+++ b/sources/OpenMcdf/StreamRW.cs
@@ -41,7 +41,7 @@ namespace OpenMcdf
         public int ReadInt32()
         {
             this.stream.Read(buffer, 0, 4);
-            return (int)(buffer[0] | (buffer[1] << 8) | (buffer[2] << 16) | (buffer[3] << 24));
+            return buffer[0] | (buffer[1] << 8) | (buffer[2] << 16) | (buffer[3] << 24);
         }
 
         public uint ReadUInt32()

--- a/sources/OpenMcdf/StreamRW.cs
+++ b/sources/OpenMcdf/StreamRW.cs
@@ -6,9 +6,6 @@
  * 
  * The Initial Developer of the Original Code is Federico Blaseotto.*/
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.IO;
 
 namespace OpenMcdf

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -180,7 +180,7 @@ namespace OpenMcdf
 
                 if (nToRead != 0)
                 {
-					if (secIndex > sectorChain.Count) throw new CFCorruptedFileException("The file is probably corrupted.");
+                    if (secIndex > sectorChain.Count) throw new CFCorruptedFileException("The file is probably corrupted.");
 
                     Buffer.BlockCopy(
                         sectorChain[secIndex].GetData(),

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -16,7 +16,7 @@ namespace OpenMcdf
     /// <summary>
     /// Stream decorator for a Sector or miniSector chain
     /// </summary>
-    internal class StreamView : Stream
+    internal sealed class StreamView : Stream
     {
         private int sectorSize;
 

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -220,7 +220,7 @@ namespace OpenMcdf
                     break;
             }
 
-            if (this.length <= position) // Dont't adjust the length when position is inside the bounds of 0 and the current length.
+            if (this.length <= position) // Don't adjust the length when position is inside the bounds of 0 and the current length.
                 adjustLength(position);
 
             return position;
@@ -239,7 +239,7 @@ namespace OpenMcdf
 
             if (delta > 0)
             {
-                // enlargment required
+                // Enlargement required
 
                 int nSec = (int)Math.Ceiling(((double)delta / sectorSize));
 

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -9,11 +9,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Collections;
 using System.IO;
-using System.Collections.Specialized;
-using System.Diagnostics;
 
 namespace OpenMcdf
 {

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -130,7 +130,7 @@ namespace OpenMcdf
             if (sectorChain != null && sectorChain.Count > 0)
             {
                 // First sector
-                int secIndex = (int)(position / (long)sectorSize);
+                int secIndex = (int)(position / sectorSize);
 
                 // Bytes to read count is the min between request count
                 // and sector border
@@ -231,7 +231,7 @@ namespace OpenMcdf
         {
             this.length = value;
 
-            long delta = value - ((long)this.sectorChain.Count * (long)sectorSize);
+            long delta = value - (sectorChain.Count * (long)sectorSize);
 
             if (delta > 0)
             {
@@ -312,10 +312,10 @@ namespace OpenMcdf
             if (sectorChain != null)
             {
                 // First sector
-                int secOffset = (int)(position / (long)sectorSize);
+                int secOffset = (int)(position / sectorSize);
                 int secShift = (int)(position % sectorSize);
 
-                roundByteWritten = (int)Math.Min(sectorSize - (int)(position % (long)sectorSize), count);
+                roundByteWritten = Math.Min(sectorSize - (int)(position % sectorSize), count);
 
                 if (secOffset < sectorChain.Count)
                 {

--- a/sources/Structured Storage Explorer/MainForm.Designer.cs
+++ b/sources/Structured Storage Explorer/MainForm.Designer.cs
@@ -88,7 +88,7 @@
             this.openFileDialog1.Filter = "Office files (*.xls *.doc *.ppt)|*.xls;*.doc;*.ppt|Thumbs db files (Thumbs.db)|*." +
     "db|MSI Setup files (*.msi)|*.msi|Advanced Authoring Format  (*.aaf)|*.aaf|All fi" +
     "les (*.*)|*.*";
-            this.openFileDialog1.Title = "Open OLE Structured Storae file";
+            this.openFileDialog1.Title = "Open OLE Structured Storage file";
             // 
             // treeView1
             // 

--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -1,20 +1,15 @@
 ﻿#define OLE_PROPERTY
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 using OpenMcdf;
 using System.IO;
-using System.Resources;
 using System.Globalization;
 using StructuredStorageExplorer.Properties;
-using Be.Windows.Forms;
 using OpenMcdf.Extensions.OLEProperties;
-using OpenMcdf.Extensions.OLEProperties.Interfaces;
 using OpenMcdf.Extensions;
 using System.Linq;
 using System.Collections;

--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -411,7 +411,7 @@ namespace StructuredStorageExplorer
         {
             // Get the node under the mouse cursor.
             // We intercept both left and right mouse clicks
-            // and set the selected treenode according.
+            // and set the selected TreeNode according.
             try
             {
                 TreeNode n = treeView1.GetNodeAt(e.X, e.Y);

--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -37,8 +37,8 @@ namespace StructuredStorageExplorer
 #endif
 
             //Load images for icons from resx
-            Image folderImage = (Image)Properties.Resources.ResourceManager.GetObject("storage");
-            Image streamImage = (Image)Properties.Resources.ResourceManager.GetObject("stream");
+            Image folderImage = (Image)Resources.ResourceManager.GetObject("storage");
+            Image streamImage = (Image)Resources.ResourceManager.GetObject("stream");
             //Image olePropsImage = (Image)Properties.Resources.ResourceManager.GetObject("oleprops");
 
             treeView1.ImageList = new ImageList();

--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -1,18 +1,18 @@
 ﻿#define OLE_PROPERTY
 
+using OpenMcdf;
+using OpenMcdf.Extensions;
+using OpenMcdf.Extensions.OLEProperties;
+using StructuredStorageExplorer.Properties;
 using System;
+using System.Collections;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-using System.Windows.Forms;
-using OpenMcdf;
-using System.IO;
 using System.Globalization;
-using StructuredStorageExplorer.Properties;
-using OpenMcdf.Extensions.OLEProperties;
-using OpenMcdf.Extensions;
+using System.IO;
 using System.Linq;
-using System.Collections;
+using System.Windows.Forms;
 
 // Author Federico Blaseotto
 

--- a/sources/Structured Storage Explorer/PreferencesForm.cs
+++ b/sources/Structured Storage Explorer/PreferencesForm.cs
@@ -17,7 +17,7 @@ namespace StructuredStorageExplorer
             InitializeComponent();
         }
 
-        
+
 
         private void btnSavePreferences_Click(object sender, EventArgs e)
         {

--- a/sources/Structured Storage Explorer/PreferencesForm.cs
+++ b/sources/Structured Storage Explorer/PreferencesForm.cs
@@ -1,11 +1,5 @@
 ﻿using StructuredStorageExplorer.Properties;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace StructuredStorageExplorer

--- a/sources/Structured Storage Explorer/Program.cs
+++ b/sources/Structured Storage Explorer/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace StructuredStorageExplorer

--- a/sources/Structured Storage Explorer/Properties/AssemblyInfo.cs
+++ b/sources/Structured Storage Explorer/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/Structured Storage Explorer/Properties/AssemblyInfo.cs
+++ b/sources/Structured Storage Explorer/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("StucturedStorageExplorer")]
-[assembly: AssemblyDescription("COM/OLE Stuctured Storage Viewer - Sample application for OpenMCDF component.")]
+[assembly: AssemblyDescription("COM/OLE Structured Storage Viewer - Sample application for OpenMCDF component.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("StucturedStorageExplorer")]

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using Be.Windows.Forms;
+﻿using Be.Windows.Forms;
 using OpenMcdf;
+using System;
 
 namespace StructuredStorageExplorer
 {

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Be.Windows.Forms;
 using OpenMcdf;
 

--- a/sources/Structured Storage Explorer/Utils.cs
+++ b/sources/Structured Storage Explorer/Utils.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Windows.Forms;
 using System.Drawing;
 using OpenMcdf;

--- a/sources/Structured Storage Explorer/Utils.cs
+++ b/sources/Structured Storage Explorer/Utils.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Windows.Forms;
+﻿using OpenMcdf;
+using System;
 using System.Drawing;
-using OpenMcdf;
+using System.Windows.Forms;
 
 namespace StructuredStorageExplorer
 {

--- a/sources/Test/OpenMcdf.Benchmark/Extensions.cs
+++ b/sources/Test/OpenMcdf.Benchmark/Extensions.cs
@@ -1,6 +1,6 @@
-﻿using System.IO;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using OpenMcdf.Extensions;
+using System.IO;
 
 namespace OpenMcdf.Benchmark
 {

--- a/sources/Test/OpenMcdf.Benchmark/Extensions.cs
+++ b/sources/Test/OpenMcdf.Benchmark/Extensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using BenchmarkDotNet.Attributes;
 using OpenMcdf.Extensions;
 

--- a/sources/Test/OpenMcdf.Benchmark/InMemory.cs
+++ b/sources/Test/OpenMcdf.Benchmark/InMemory.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.IO;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using System;
+using System.IO;
 
 namespace OpenMcdf.Benchmark
 {

--- a/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OpenMcdf.Extensions.Test
 {

--- a/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
@@ -13,10 +13,10 @@ namespace OpenMcdf.Extensions.Test
     {
         public CFSStreamExtensionsTest()
         {
-          
+
         }
 
-       
+
         private TestContext testContextInstance;
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace OpenMcdf.Extensions.Test
             {
                 data[i] = (byte)(i % 255);
             }
-            
+
             using (CompoundFile cf = new CompoundFile())
             {
                 using (Stream s = cf.RootStorage.AddStream("ANewStream").AsIOStream())

--- a/sources/Test/OpenMcdf.Extensions.Test/Helpers.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/Helpers.cs
@@ -28,10 +28,10 @@ namespace OpenMcdf.Extensions.Test
             if (b == null && p == null)
                 throw new Exception("Null buffers");
 
-            if (b == null && p != null) 
+            if (b == null && p != null)
                 return false;
 
-            if (b != null && p == null) 
+            if (b != null && p == null)
                 return false;
 
             if (b.Length != p.Length)

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenMcdf.Extensions.OLEProperties;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
-using System.Collections.Generic;
-using OpenMcdf.Extensions.OLEProperties;
 
 namespace OpenMcdf.Extensions.Test
 {

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -161,7 +161,7 @@ namespace OpenMcdf.Extensions.Test
 
                 co.Save(dsiStream);
                 cf.SaveAs(@"test_modify_summary.ppt");
-                cf.Close() ;
+                cf.Close();
             }
 
             using (CompoundFile cf = new CompoundFile("test_modify_summary.ppt"))
@@ -212,7 +212,8 @@ namespace OpenMcdf.Extensions.Test
 
                     Assert.IsNotNull(co2.Properties);
                 }
-            }catch(Exception ex)
+            }
+            catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message);
                 Assert.Fail();
@@ -252,7 +253,7 @@ namespace OpenMcdf.Extensions.Test
                         Debug.WriteLine(p.Value);
                     }
 
-                    
+
                     Assert.IsNotNull(co2.UserDefinedProperties.Properties);
                     foreach (OLEProperties.OLEProperty p in co2.UserDefinedProperties.Properties)
                     {
@@ -352,10 +353,10 @@ namespace OpenMcdf.Extensions.Test
                 // There should be 5 property names present, and 6 properties (the properties include the code page)
                 Assert.AreEqual(5, userProps.PropertyNames.Count);
                 Assert.AreEqual(6, userProps.Properties.Count());
-                
+
                 // Check for expected names and values
                 var propArray = userProps.Properties.ToArray();
-                
+
                 // CodePage prop
                 Assert.AreEqual(1u, propArray[0].PropertyIdentifier);
                 Assert.AreEqual("0x00000001", propArray[0].PropertyName);
@@ -465,7 +466,7 @@ namespace OpenMcdf.Extensions.Test
                 var docPartsProperty = co.Properties.FirstOrDefault(property => property.PropertyIdentifier == 13); //13 == PIDDSI_DOCPARTS
 
                 Assert.IsNotNull(docPartsProperty);
-                
+
                 var docPartsValues = docPartsProperty.Value as IEnumerable<string>;
                 Assert.AreEqual(3, docPartsValues.Count());
                 Assert.AreEqual("Sheet1", docPartsValues.ElementAt(0));
@@ -473,7 +474,7 @@ namespace OpenMcdf.Extensions.Test
                 Assert.AreEqual("Sheet3", docPartsValues.ElementAt(2));
             }
         }
-      
+
         [TestMethod]
         public void Test_CLSID_PROPERTY()
         {

--- a/sources/Test/OpenMcdf.Extensions.Test/Properties/AssemblyInfo.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/Test/OpenMcdf.MemTest/Program.cs
+++ b/sources/Test/OpenMcdf.MemTest/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Diagnostics;
-
-using OpenMcdf;
 //This project is used for profiling memory and performances of OpenMCDF .
 
 namespace OpenMcdf.MemTest

--- a/sources/Test/OpenMcdf.MemTest/Program.cs
+++ b/sources/Test/OpenMcdf.MemTest/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.IO;
 using System.Diagnostics;
+using System.IO;
 //This project is used for profiling memory and performances of OpenMCDF .
 
 namespace OpenMcdf.MemTest

--- a/sources/Test/OpenMcdf.MemTest/Program.cs
+++ b/sources/Test/OpenMcdf.MemTest/Program.cs
@@ -217,7 +217,7 @@ namespace OpenMcdf.MemTest
         private static void AddNodes(String depth, CFStorage cfs)
         {
 
-            Action<CFItem> va = delegate(CFItem target)
+            Action<CFItem> va = delegate (CFItem target)
             {
 
                 String temp = target.Name + (target is CFStorage ? "" : " (" + target.Size + " bytes )");

--- a/sources/Test/OpenMcdf.MemTest/Properties/AssemblyInfo.cs
+++ b/sources/Test/OpenMcdf.MemTest/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/Test/OpenMcdf.PerfTest/Helpers.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Helpers.cs
@@ -30,10 +30,10 @@ namespace OpenMcdf.PerfTest
             if (b == null && p == null)
                 throw new Exception("Null buffers");
 
-            if (b == null && p != null) 
+            if (b == null && p != null)
                 return false;
 
-            if (b != null && p == null) 
+            if (b != null && p == null)
                 return false;
 
             if (b.Length != p.Length)

--- a/sources/Test/OpenMcdf.PerfTest/Helpers.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Helpers.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace OpenMcdf.PerfTest
 {

--- a/sources/Test/OpenMcdf.PerfTest/Program.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using OpenMcdf;
 using System.IO;
 
 namespace OpenMcdf.PerfTest

--- a/sources/Test/OpenMcdf.PerfTest/Properties/AssemblyInfo.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -610,7 +610,7 @@ namespace OpenMcdf.Test
 
             CompoundFile cf2 = new CompoundFile(filename);
 
-            // Execption in next line!
+            // Exception in next line!
             cf2.RootStorage.Delete(zeroLengthName);
 
             CFStream zeroStream2 = null;
@@ -1134,7 +1134,7 @@ namespace OpenMcdf.Test
         }
 
         /// <summary>
-        /// Resize without transitio to smaller chain has a wrong behaviour
+        /// Resize without transition to smaller chain has a wrong behavior
         /// </summary>
         [TestMethod]
         public void TEST_RESIZE_STREAM_BUG_119()

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Text;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenMcdf;
 using System.IO;
 
 namespace OpenMcdf.Test

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -1016,7 +1016,7 @@ namespace OpenMcdf.Test
             Stream a = null;
             List<Sector> temp = new List<Sector>();
             Sector s = new Sector(512);
-            Buffer.BlockCopy(BitConverter.GetBytes((int)1), 0, s.GetData(), 0, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes(1), 0, s.GetData(), 0, 4);
             temp.Add(s);
 
             StreamView sv = new StreamView(temp, 512, 4, null, a);

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System.Linq;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -482,7 +482,7 @@ namespace OpenMcdf.Test
             }
             catch (Exception ex)
             {
-               Assert.Fail(ex.Message);
+                Assert.Fail(ex.Message);
             }
 
             try
@@ -490,7 +490,8 @@ namespace OpenMcdf.Test
                 CompoundFile cf2 = new CompoundFile("Hello$File");
                 var st2 = cf2.RootStorage.GetStorage("NewStorage");
                 Assert.IsNotNull(st2);
-            }catch(Exception ex)
+            }
+            catch (Exception ex)
             {
                 Assert.Fail($"{ex.Message}");
             }

--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenMcdf;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Text;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenMcdf;
 using System.IO;
 using System.Diagnostics;
-using System.Linq.Expressions;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -880,7 +880,7 @@ namespace OpenMcdf.Test
 
         }
 
-        #region Copy heper method
+        #region Copy helper method
         /// <summary>
         /// Copies the given <paramref name="source"/> to the given <paramref name="destination"/>
         /// </summary>

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -986,7 +986,7 @@ namespace OpenMcdf.Test
             byte c = 0x0A;
             for (int i = 0; i < iterationCount; i++)
             {
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + 0.ToString()).Read(readBuffer, ((long)BUFFER_SIZE + ((long)BUFFER_SIZE * i)) - 15, 15);
+                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + 0.ToString()).Read(readBuffer, (BUFFER_SIZE + ((long)BUFFER_SIZE * i)) - 15, 15);
                 Assert.IsTrue(readBuffer.All(by => by == c));
                 c++;
             }

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -1,9 +1,9 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -778,7 +778,7 @@ namespace OpenMcdf.Test
                 CompoundFile file = new CompoundFile(fs, CFSUpdateMode.ReadOnly, CFSConfiguration.LeaveOpen);
 
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
             }
@@ -808,7 +808,7 @@ namespace OpenMcdf.Test
                 cf2.Commit();
                 cf2.Close();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
             }
@@ -1006,7 +1006,7 @@ namespace OpenMcdf.Test
                 Assert.IsTrue(st.GetData().Count() == 31220);
                 f.Close();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.Fail("Release Memory flag caused error");
             }
@@ -1086,7 +1086,7 @@ namespace OpenMcdf.Test
 
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Assert.Fail();
             }

--- a/sources/Test/OpenMcdf.Test/Helpers.cs
+++ b/sources/Test/OpenMcdf.Test/Helpers.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/Helpers.cs
+++ b/sources/Test/OpenMcdf.Test/Helpers.cs
@@ -20,7 +20,7 @@ namespace OpenMcdf.Test
             Random r = new Random();
             r.NextBytes(buffer);
         }
-        public static void FillBuffer(byte[] buffer,byte c)
+        public static void FillBuffer(byte[] buffer, byte c)
         {
             for (int i = 0; i < buffer.Length; i++)
             {
@@ -31,7 +31,7 @@ namespace OpenMcdf.Test
         public static byte[] GetBuffer(int count, byte c)
         {
             byte[] b = new byte[count];
-            FillBuffer(b,c);
+            FillBuffer(b, c);
             return b;
         }
 

--- a/sources/Test/OpenMcdf.Test/Properties/AssemblyInfo.cs
+++ b/sources/Test/OpenMcdf.Test/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components. If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/sources/Test/OpenMcdf.Test/RBTreeTest.cs
+++ b/sources/Test/OpenMcdf.Test/RBTreeTest.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RedBlackTree;
+using System;
+using System.Collections.Generic;
 
 namespace OpenMcdf.Test
 {

--- a/sources/Test/OpenMcdf.Test/RBTreeTest.cs
+++ b/sources/Test/OpenMcdf.Test/RBTreeTest.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Text;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenMcdf;
 using RedBlackTree;
 
 namespace OpenMcdf.Test

--- a/sources/Test/OpenMcdf.Test/RBTreeTest.cs
+++ b/sources/Test/OpenMcdf.Test/RBTreeTest.cs
@@ -16,7 +16,7 @@ namespace OpenMcdf.Test
     {
         public RBTreeTest()
         {
-            
+
         }
 
         private TestContext testContextInstance;
@@ -64,7 +64,7 @@ namespace OpenMcdf.Test
             List<IDirectoryEntry> repo = new List<IDirectoryEntry>();
             for (int i = 0; i < count; i++)
             {
-                IDirectoryEntry de =  DirectoryEntry.New(i.ToString(), StgType.StgInvalid, repo);
+                IDirectoryEntry de = DirectoryEntry.New(i.ToString(), StgType.StgInvalid, repo);
             }
 
             return repo;
@@ -107,7 +107,7 @@ namespace OpenMcdf.Test
             try
             {
                 IRBNode n;
-                rbTree.Delete(DirectoryEntry.Mock("5", StgType.StgInvalid),out n);
+                rbTree.Delete(DirectoryEntry.Mock("5", StgType.StgInvalid), out n);
                 rbTree.Delete(DirectoryEntry.Mock("24", StgType.StgInvalid), out n);
                 rbTree.Delete(DirectoryEntry.Mock("7", StgType.StgInvalid), out n);
             }
@@ -134,7 +134,7 @@ namespace OpenMcdf.Test
 
             //}
 
-          
+
         }
 
         private static void VerifyProperties(RBTree t)
@@ -146,7 +146,7 @@ namespace OpenMcdf.Test
             VerifyProperty5(t.Root);
         }
 
-        private static Color NodeColor(IRBNode n) 
+        private static Color NodeColor(IRBNode n)
         {
             return n == null ? Color.BLACK : n.Color;
         }
@@ -166,7 +166,7 @@ namespace OpenMcdf.Test
             Assert.IsTrue(NodeColor(root) == Color.BLACK);
         }
 
-        private static void VerifyProperty4(IRBNode n) 
+        private static void VerifyProperty4(IRBNode n)
         {
 
             if (NodeColor(n) == Color.RED)

--- a/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
+++ b/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
@@ -71,7 +71,7 @@ namespace OpenMcdf.Test
         [TestMethod()]
         public void CountTest()
         {
-            
+
             int count = 0;
 
             SectorCollection target = new SectorCollection(); // TODO: Initialize to an appropriate value
@@ -181,7 +181,7 @@ namespace OpenMcdf.Test
                 target.Add(null);
             }
 
-            
+
             Sector item = new Sector(4096);
             target.Add(item);
             Assert.IsTrue(target.Count == 580);

--- a/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
+++ b/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
@@ -1,6 +1,4 @@
-﻿using OpenMcdf;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
 namespace OpenMcdf.Test

--- a/sources/Test/OpenMcdf.Test/StreamRWTest.cs
+++ b/sources/Test/OpenMcdf.Test/StreamRWTest.cs
@@ -18,7 +18,7 @@ namespace OpenMcdf.Test
                 OpenMcdf.StreamRW reader = new OpenMcdf.StreamRW(memStream);
                 actual = reader.ReadInt64();
             }
-            Assert.AreEqual((long)input, actual);
+            Assert.AreEqual(input, actual);
         }
 
         [TestMethod]
@@ -32,7 +32,7 @@ namespace OpenMcdf.Test
                 OpenMcdf.StreamRW reader = new OpenMcdf.StreamRW(memStream);
                 actual = reader.ReadInt64();
             }
-            Assert.AreEqual((long)input, actual);
+            Assert.AreEqual(input, actual);
         }
 
         [TestMethod]
@@ -46,7 +46,7 @@ namespace OpenMcdf.Test
                 OpenMcdf.StreamRW reader = new OpenMcdf.StreamRW(memStream);
                 actual = reader.ReadInt64();
             }
-            Assert.AreEqual((long)input, actual);
+            Assert.AreEqual(input, actual);
         }
     }
 }

--- a/sources/Test/OpenMcdf.Test/StreamRWTest.cs
+++ b/sources/Test/OpenMcdf.Test/StreamRWTest.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.IO;
 
 namespace OpenMcdf.Test


### PR DESCRIPTION
A collection of non-contentious correctness fixes in preparation for more significant/functional changes.
Basically just fixing spelling mistakes and applying some automatic fixes from the IDE.
Next step would be to add an editorconfig in-line with existing project conventions.