### PR TITLE
Use SimpleJob instead of CoreJob in the 'InMemory' benchmark

### DIFF
--- a/sources/Test/OpenMcdf.Benchmark/InMemory.cs
+++ b/sources/Test/OpenMcdf.Benchmark/InMemory.cs
@@ -1,11 +1,12 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Jobs;
 using System;
 using System.IO;
 
 namespace OpenMcdf.Benchmark
 {
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [CsvExporter]
     [HtmlExporter]
     [MarkdownExporter]


### PR DESCRIPTION
Just fixes this deprecation warning in the build:

![image](https://github.com/user-attachments/assets/7a46616f-5264-4399-9649-914d005c9d4b)
