### PR TITLE
Target net6.0 for OpenMcdf.Benchmark

### DIFF
--- a/sources/Test/OpenMcdf.Benchmark/Extensions.cs
+++ b/sources/Test/OpenMcdf.Benchmark/Extensions.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace OpenMcdf.Benchmark
 {
     // Simple benchmarks for reading OLE Properties with OpenMcdf.Extensions.
-    [SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class ExtensionsRead
     {

--- a/sources/Test/OpenMcdf.Benchmark/InMemory.cs
+++ b/sources/Test/OpenMcdf.Benchmark/InMemory.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace OpenMcdf.Benchmark
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob]
     [CsvExporter]
     [HtmlExporter]
     [MarkdownExporter]

--- a/sources/Test/OpenMcdf.Benchmark/OpenMcdf.Benchmark.csproj
+++ b/sources/Test/OpenMcdf.Benchmark/OpenMcdf.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
netcoreapp3.1 is obsolete and unsupported

Even net6.0 will be EOL towards the end of the year...
https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core