### PR TITLE
Analyzer fixes

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryEntry.cs
@@ -6,7 +6,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 {
     public class DictionaryEntry
     {
-        int codePage;
+        readonly int codePage;
 
         public DictionaryEntry(int codePage)
         {

--- a/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/DictionaryProperty.cs
@@ -7,7 +7,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 {
     public class DictionaryProperty : IDictionaryProperty
     {
-        private int codePage;
+        private readonly int codePage;
 
         public DictionaryProperty(int codePage)
         {

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -19,7 +19,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         public PropertyContext Context { get; private set; }
 
-        private List<OLEProperty> properties = new List<OLEProperty>();
+        private readonly List<OLEProperty> properties = new List<OLEProperty>();
         internal CFStream cfStream;
 
         /*

--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEProperty.cs
@@ -5,7 +5,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 {
     public class OLEProperty
     {
-        private OLEPropertiesContainer container;
+        private readonly OLEPropertiesContainer container;
 
         internal OLEProperty(OLEPropertiesContainer container)
         {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -381,7 +381,7 @@ namespace OpenMcdf.Extensions.OLEProperties
         protected class VT_LPSTR_Property : TypedPropertyValue<string>
         {
             private byte[] data;
-            private int codePage;
+            private readonly int codePage;
 
             public VT_LPSTR_Property(VTPropertyType vType, int codePage, bool isVariant) : base(vType, isVariant)
             {
@@ -481,7 +481,7 @@ namespace OpenMcdf.Extensions.OLEProperties
         private class VT_LPWSTR_Property : TypedPropertyValue<string>
         {
             private byte[] data;
-            private int codePage;
+            private readonly int codePage;
 
             public VT_LPWSTR_Property(VTPropertyType vType, int codePage, bool isVariant) : base(vType, isVariant)
             {

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -16,8 +16,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         public ITypedPropertyValue NewProperty(VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant = false)
         {
-            ITypedPropertyValue pr = null;
-
+            ITypedPropertyValue pr;
             switch ((VTPropertyType)((ushort)vType & 0x00FF))
             {
                 case VTPropertyType.VT_I1:

--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertySet.cs
@@ -16,27 +16,9 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         public uint NumProperties { get; set; }
 
-        List<PropertyIdentifierAndOffset> propertyIdentifierAndOffsets
-            = new List<PropertyIdentifierAndOffset>();
+        public List<PropertyIdentifierAndOffset> PropertyIdentifierAndOffsets { get; set; } = new List<PropertyIdentifierAndOffset>();
 
-        public List<PropertyIdentifierAndOffset> PropertyIdentifierAndOffsets
-        {
-            get { return propertyIdentifierAndOffsets; }
-            set { propertyIdentifierAndOffsets = value; }
-        }
-
-        List<IProperty> properties = new List<IProperty>();
-        public List<IProperty> Properties
-        {
-            get
-            {
-                return properties;
-            }
-            set
-            {
-                properties = value;
-            }
-        }
+        public List<IProperty> Properties { get; set; } = new List<IProperty>();
 
         public void LoadContext(int propertySetOffset, BinaryReader br)
         {

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -110,9 +110,8 @@ namespace OpenMcdf.Extensions.OLEProperties
         public void Write(BinaryWriter bw)
         {
             long currentPos = bw.BaseStream.Position;
-            int size = 0;
-            int m = 0;
-
+            int size;
+            int m;
             switch (this.PropertyDimensions)
             {
                 case PropertyDimensions.IsScalar:

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -6,7 +6,7 @@ namespace OpenMcdf.Extensions.OLEProperties
 {
     internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
     {
-        private VTPropertyType _VTType;
+        private readonly VTPropertyType _VTType;
 
         public PropertyType PropertyType => PropertyType.TypedPropertyValue;
 

--- a/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/TypedPropertyValue.cs
@@ -6,9 +6,6 @@ namespace OpenMcdf.Extensions.OLEProperties
 {
     internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
     {
-        private bool isVariant = false;
-        private PropertyDimensions dim = PropertyDimensions.IsScalar;
-
         private VTPropertyType _VTType;
 
         public PropertyType PropertyType => PropertyType.TypedPropertyValue;
@@ -20,13 +17,13 @@ namespace OpenMcdf.Extensions.OLEProperties
         public TypedPropertyValue(VTPropertyType vtType, bool isVariant = false)
         {
             this._VTType = vtType;
-            dim = CheckPropertyDimensions(vtType);
-            this.isVariant = isVariant;
+            PropertyDimensions = CheckPropertyDimensions(vtType);
+            this.IsVariant = isVariant;
         }
 
-        public PropertyDimensions PropertyDimensions => dim;
+        public PropertyDimensions PropertyDimensions { get; } = PropertyDimensions.IsScalar;
 
-        public bool IsVariant => isVariant;
+        public bool IsVariant { get; } = false;
 
         protected virtual bool NeedsPadding { get; set; } = true;
 

--- a/sources/OpenMcdf.Extensions/StreamDecorator.cs
+++ b/sources/OpenMcdf.Extensions/StreamDecorator.cs
@@ -8,7 +8,7 @@ namespace OpenMcdf.Extensions
     /// </summary>
     public class StreamDecorator : Stream
     {
-        private CFStream cfStream;
+        private readonly CFStream cfStream;
         private long position = 0;
 
         /// <summary>

--- a/sources/OpenMcdf/CFItem.cs
+++ b/sources/OpenMcdf/CFItem.cs
@@ -37,13 +37,11 @@ namespace OpenMcdf
     /// </example>
     public abstract class CFItem : IComparable<CFItem>
     {
-        private CompoundFile compoundFile;
-
-        protected CompoundFile CompoundFile => compoundFile;
+        protected CompoundFile CompoundFile { get; }
 
         protected void CheckDisposed()
         {
-            if (compoundFile.IsClosed)
+            if (CompoundFile.IsClosed)
                 throw new CFDisposedException("Owner Compound file has been closed and owned items have been invalidated");
         }
 
@@ -53,22 +51,17 @@ namespace OpenMcdf
 
         protected CFItem(CompoundFile compoundFile)
         {
-            this.compoundFile = compoundFile;
+            this.CompoundFile = compoundFile;
         }
 
         #region IDirectoryEntry Members
 
-        private IDirectoryEntry dirEntry;
 
-        internal IDirectoryEntry DirEntry
-        {
-            get { return dirEntry; }
-            set { dirEntry = value; }
-        }
+        internal IDirectoryEntry DirEntry { get; set; }
 
         internal int CompareTo(CFItem other)
         {
-            return this.dirEntry.CompareTo(other.DirEntry);
+            return this.DirEntry.CompareTo(other.DirEntry);
         }
 
         #endregion
@@ -77,7 +70,7 @@ namespace OpenMcdf
 
         public int CompareTo(object obj)
         {
-            return this.dirEntry.CompareTo(((CFItem)obj).DirEntry);
+            return this.DirEntry.CompareTo(((CFItem)obj).DirEntry);
         }
 
         #endregion
@@ -112,7 +105,7 @@ namespace OpenMcdf
 
         public override int GetHashCode()
         {
-            return this.dirEntry.GetEntryName().GetHashCode();
+            return this.DirEntry.GetEntryName().GetHashCode();
         }
 
         /// <summary>
@@ -122,7 +115,7 @@ namespace OpenMcdf
         {
             get
             {
-                string n = this.dirEntry.GetEntryName();
+                string n = this.DirEntry.GetEntryName();
                 if (n != null && n.Length > 0)
                 {
                     return n.TrimEnd('\0');
@@ -136,7 +129,7 @@ namespace OpenMcdf
         /// Size in bytes of the item. It has a valid value
         /// only if entity is a stream, otherwise it is set to zero.
         /// </summary>
-        public long Size => this.dirEntry.Size;
+        public long Size => this.DirEntry.Size;
 
         /// <summary>
         /// Return true if item is Storage
@@ -145,7 +138,7 @@ namespace OpenMcdf
         /// This check doesn't use reflection or runtime type information
         /// and doesn't suffer related performance penalties.
         /// </remarks>
-        public bool IsStorage => this.dirEntry.StgType == StgType.StgStorage;
+        public bool IsStorage => this.DirEntry.StgType == StgType.StgStorage;
 
         /// <summary>
         /// Return true if item is a Stream
@@ -154,7 +147,7 @@ namespace OpenMcdf
         /// This check doesn't use reflection or runtime type information
         /// and doesn't suffer related performance penalties.
         /// </remarks>
-        public bool IsStream => this.dirEntry.StgType == StgType.StgStream;
+        public bool IsStream => this.DirEntry.StgType == StgType.StgStream;
 
         /// <summary>
         /// Return true if item is the Root Storage
@@ -163,7 +156,7 @@ namespace OpenMcdf
         /// This check doesn't use reflection or runtime type information
         /// and doesn't suffer related performance penalties.
         /// </remarks>
-        public bool IsRoot => this.dirEntry.StgType == StgType.StgRoot;
+        public bool IsRoot => this.DirEntry.StgType == StgType.StgRoot;
 
         /// <summary>
         /// Get/Set the Creation Date of the current item
@@ -172,13 +165,13 @@ namespace OpenMcdf
         {
             get
             {
-                return DateTime.FromFileTime(BitConverter.ToInt64(this.dirEntry.CreationDate, 0));
+                return DateTime.FromFileTime(BitConverter.ToInt64(this.DirEntry.CreationDate, 0));
             }
 
             set
             {
-                if (this.dirEntry.StgType != StgType.StgStream && this.dirEntry.StgType != StgType.StgRoot)
-                    this.dirEntry.CreationDate = BitConverter.GetBytes(value.ToFileTime());
+                if (this.DirEntry.StgType != StgType.StgStream && this.DirEntry.StgType != StgType.StgRoot)
+                    this.DirEntry.CreationDate = BitConverter.GetBytes(value.ToFileTime());
                 else
                     throw new CFException("Creation Date can only be set on storage entries");
             }
@@ -191,13 +184,13 @@ namespace OpenMcdf
         {
             get
             {
-                return DateTime.FromFileTime(BitConverter.ToInt64(this.dirEntry.ModifyDate, 0));
+                return DateTime.FromFileTime(BitConverter.ToInt64(this.DirEntry.ModifyDate, 0));
             }
 
             set
             {
-                if (this.dirEntry.StgType != StgType.StgStream && this.dirEntry.StgType != StgType.StgRoot)
-                    this.dirEntry.ModifyDate = BitConverter.GetBytes(value.ToFileTime());
+                if (this.DirEntry.StgType != StgType.StgStream && this.DirEntry.StgType != StgType.StgRoot)
+                    this.DirEntry.ModifyDate = BitConverter.GetBytes(value.ToFileTime());
                 else
                     throw new CFException("Modify Date can only be set on storage entries");
             }
@@ -210,13 +203,13 @@ namespace OpenMcdf
         {
             get
             {
-                return this.dirEntry.StorageCLSID;
+                return this.DirEntry.StorageCLSID;
             }
             set
             {
-                if (this.dirEntry.StgType != StgType.StgStream)
+                if (this.DirEntry.StgType != StgType.StgStream)
                 {
-                    this.dirEntry.StorageCLSID = value;
+                    this.DirEntry.StorageCLSID = value;
                 }
                 else
                     throw new CFException("Object class GUID can only be set on Root and Storage entries");
@@ -225,13 +218,13 @@ namespace OpenMcdf
 
         int IComparable<CFItem>.CompareTo(CFItem other)
         {
-            return this.dirEntry.CompareTo(other.DirEntry);
+            return this.DirEntry.CompareTo(other.DirEntry);
         }
 
         public override string ToString()
         {
-            if (this.dirEntry != null)
-                return "[" + this.dirEntry.LeftSibling + "," + this.dirEntry.SID + "," + this.dirEntry.RightSibling + "]" + " " + this.dirEntry.GetEntryName();
+            if (this.DirEntry != null)
+                return "[" + this.DirEntry.LeftSibling + "," + this.DirEntry.SID + "," + this.DirEntry.RightSibling + "]" + " " + this.DirEntry.GetEntryName();
             else
                 return string.Empty;
         }

--- a/sources/OpenMcdf/CFStorage.cs
+++ b/sources/OpenMcdf/CFStorage.cs
@@ -442,7 +442,6 @@ namespace OpenMcdf
             catch (RBTreeDuplicatedItemException)
             {
                 CompoundFile.ResetDirectoryEntry(cfo.SID);
-                cfo = null;
                 throw new CFDuplicatedItemException("An entry with name '" + storageName + "' is already present in storage '" + this.Name + "' ");
             }
 
@@ -547,7 +546,7 @@ namespace OpenMcdf
             if (((IDirectoryEntry)foundObj).StgType == StgType.StgRoot)
                 throw new CFException("Root storage cannot be removed");
 
-            IRBNode altDel = null;
+            IRBNode altDel;
             switch (((IDirectoryEntry)foundObj).StgType)
             {
                 case StgType.StgStorage:

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -826,8 +826,7 @@ namespace OpenMcdf
             if (stream.Size == 0)
                 return;
 
-            List<Sector> sectorChain = null;
-
+            List<Sector> sectorChain;
             if (stream.Size < header.MinSizeStandardStream)
             {
                 sectorChain = GetSectorChain(stream.DirEntry.StartSetc, SectorType.Mini);
@@ -1212,20 +1211,13 @@ namespace OpenMcdf
         /// <returns>A list of DIFAT sectors</returns>
         private List<Sector> GetDifatSectorChain()
         {
-            int validationCount = 0;
-
             List<Sector> result
                 = new List<Sector>();
-
-            int nextSecID
-               = Sector.ENDOFCHAIN;
-
             HashSet<int> processedSectors = new HashSet<int>();
 
             if (header.DIFATSectorsNumber != 0)
             {
-                validationCount = (int)header.DIFATSectorsNumber;
-
+                int validationCount = (int)header.DIFATSectorsNumber;
                 Sector s = sectors[header.FirstDIFATSectorID];
 
                 if (s == null) //Lazy loading
@@ -1240,7 +1232,7 @@ namespace OpenMcdf
 
                 while (true && validationCount >= 0)
                 {
-                    nextSecID = BitConverter.ToInt32(s.GetData(), GetSectorSize() - 4);
+                    int nextSecID = BitConverter.ToInt32(s.GetData(), GetSectorSize() - 4);
                     EnsureUniqueSectorIndex(nextSecID, processedSectors);
 
                     // Strictly speaking, the following condition is not correct from
@@ -1299,14 +1291,12 @@ namespace OpenMcdf
 
             List<Sector> result
                = new List<Sector>();
-
-            int nextSecID
-               = Sector.ENDOFCHAIN;
-
             List<Sector> difatSectors = GetDifatSectorChain();
 
             int idx = 0;
 
+
+            int nextSecID;
             // Read FAT entries from the header Fat entry array (max 109 entries)
             while (idx < header.FATSectorsNumber && idx < N_HEADER_FAT_ENTRY)
             {
@@ -1446,8 +1436,6 @@ namespace OpenMcdf
 
             if (secID != Sector.ENDOFCHAIN)
             {
-                int nextSecID = secID;
-
                 List<Sector> miniFAT = GetNormalSectorChain(header.FirstMiniFATSectorID);
                 List<Sector> miniStream = GetNormalSectorChain(RootEntry.StartSetc);
 
@@ -1459,8 +1447,7 @@ namespace OpenMcdf
 
                 BinaryReader miniFATReader = new BinaryReader(miniFATView);
 
-                nextSecID = secID;
-
+                int nextSecID = secID;
                 HashSet<int> processedSectors = new HashSet<int>();
 
                 while (true)
@@ -2113,8 +2100,7 @@ namespace OpenMcdf
             }
 
             Queue<Sector> freeList = null;
-            StreamView sv = null;
-
+            StreamView sv;
             if (!transitionToMini && !transitionToNormal) //############  NO TRANSITION
             {
                 if (delta > 0) // Enlarging stream...
@@ -2321,8 +2307,7 @@ namespace OpenMcdf
 
             count = (int)Math.Min(de.Size - position, count);
 
-            StreamView sView = null;
-
+            StreamView sView;
             if (de.Size < header.MinSizeStandardStream)
             {
                 sView
@@ -2345,8 +2330,7 @@ namespace OpenMcdf
 
             count = (int)Math.Min(buffer.Length - offset, (long)count);
 
-            StreamView sView = null;
-
+            StreamView sView;
             if (de.Size < header.MinSizeStandardStream)
             {
                 sView
@@ -2367,11 +2351,10 @@ namespace OpenMcdf
         {
             if (IsClosed)
                 throw new CFDisposedException("Compound File closed: cannot access data");
-
-            byte[] result = null;
-
             IDirectoryEntry de = cFStream.DirEntry;
 
+
+            byte[] result;
             //IDirectoryEntry root = directoryEntries[0];
 
             if (de.Size < header.MinSizeStandardStream)
@@ -2403,7 +2386,7 @@ namespace OpenMcdf
                 throw new CFDisposedException("Compound File closed: cannot access data");
             if (sid < 0)
                 return null;
-            byte[] result = null;
+            byte[] result;
             try
             {
                 IDirectoryEntry de = directoryEntries[sid];

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -163,7 +163,7 @@ namespace OpenMcdf
 
         public bool ValidationExceptionEnabled { get; private set; } = true;
 
-        private CFSUpdateMode updateMode = CFSUpdateMode.ReadOnly;
+        private readonly CFSUpdateMode updateMode = CFSUpdateMode.ReadOnly;
         private string fileName = string.Empty;
 
         /// <summary>
@@ -1630,7 +1630,7 @@ namespace OpenMcdf
             de.Right = null;
         }
 
-        private List<int> levelSIDs = new List<int>();
+        private readonly List<int> levelSIDs = new List<int>();
 
         // Doubling methods allows iterative behavior while avoiding
         // to insert duplicate items
@@ -2536,7 +2536,7 @@ namespace OpenMcdf
 
         #endregion
 
-        private object lockObject = new object();
+        private readonly object lockObject = new object();
 
         /// <summary>
         /// When called from user code, release all resources, otherwise, in the case runtime called it,

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -35,12 +35,7 @@ namespace OpenMcdf
         internal const int OTHER_IS_GREATER = -1;
         private IList<IDirectoryEntry> dirRepository;
 
-        private int sid = -1;
-        public int SID
-        {
-            get { return sid; }
-            set { sid = value; }
-        }
+        public int SID { get; set; } = -1;
 
         internal static int NOSTREAM
             = unchecked((int)0xFFFFFFFF);
@@ -52,11 +47,11 @@ namespace OpenMcdf
         {
             this.dirRepository = dirRepository;
 
-            this.stgType = stgType;
+            this.StgType = stgType;
 
             if (stgType == StgType.StgStorage)
             {
-                this.creationDate = BitConverter.GetBytes(DateTime.Now.ToFileTime());
+                this.CreationDate = BitConverter.GetBytes(DateTime.Now.ToFileTime());
                 this.StartSetc = ZERO;
             }
 
@@ -71,15 +66,13 @@ namespace OpenMcdf
             }
         }
 
-        private byte[] entryName = new byte[64];
-
-        public byte[] EntryName => entryName;
+        public byte[] EntryName { get; private set; } = new byte[64];
 
         public string GetEntryName()
         {
-            if (entryName != null && entryName.Length > 0)
+            if (EntryName != null && EntryName.Length > 0)
             {
-                return Encoding.Unicode.GetString(entryName).Remove((this.nameLength - 1) / 2);
+                return Encoding.Unicode.GetString(EntryName).Remove((this.nameLength - 1) / 2);
             }
             else
                 return string.Empty;
@@ -89,7 +82,7 @@ namespace OpenMcdf
         {
             if (entryName == string.Empty)
             {
-                this.entryName = new byte[64];
+                this.EntryName = new byte[64];
                 this.nameLength = 0;
             }
             else
@@ -111,7 +104,7 @@ namespace OpenMcdf
                 newName[temp.Length] = 0x00;
                 newName[temp.Length + 1] = 0x00;
 
-                this.entryName = newName;
+                this.EntryName = newName;
                 this.nameLength = (ushort)(temp.Length + 2);
             }
         }
@@ -129,53 +122,15 @@ namespace OpenMcdf
             }
         }
 
-        private StgType stgType = StgType.StgInvalid;
-        public StgType StgType
-        {
-            get
-            {
-                return stgType;
-            }
-            set
-            {
-                stgType = value;
-            }
-        }
+        public StgType StgType { get; set; } = StgType.StgInvalid;
 
-        private StgColor stgColor = StgColor.Red;
+        public StgColor StgColor { get; set; } = StgColor.Red;
 
-        public StgColor StgColor
-        {
-            get
-            {
-                return stgColor;
-            }
-            set
-            {
-                stgColor = value;
-            }
-        }
+        public int LeftSibling { get; set; } = NOSTREAM;
 
-        private int leftSibling = NOSTREAM;
-        public int LeftSibling
-        {
-            get { return leftSibling; }
-            set { leftSibling = value; }
-        }
+        public int RightSibling { get; set; } = NOSTREAM;
 
-        private int rightSibling = NOSTREAM;
-        public int RightSibling
-        {
-            get { return rightSibling; }
-            set { rightSibling = value; }
-        }
-
-        private int child = NOSTREAM;
-        public int Child
-        {
-            get { return child; }
-            set { child = value; }
-        }
+        public int Child { get; set; } = NOSTREAM;
 
         private Guid storageCLSID
             = Guid.Empty;
@@ -192,67 +147,15 @@ namespace OpenMcdf
             }
         }
 
-        private int stateBits;
+        public int StateBits { get; set; }
 
-        public int StateBits
-        {
-            get { return stateBits; }
-            set { stateBits = value; }
-        }
+        public byte[] CreationDate { get; set; } = new byte[8] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-        private byte[] creationDate = new byte[8] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        public byte[] ModifyDate { get; set; } = new byte[8] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-        public byte[] CreationDate
-        {
-            get
-            {
-                return creationDate;
-            }
-            set
-            {
-                creationDate = value;
-            }
-        }
+        public int StartSetc { get; set; } = Sector.ENDOFCHAIN;
 
-        private byte[] modifyDate = new byte[8] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-
-        public byte[] ModifyDate
-        {
-            get
-            {
-                return modifyDate;
-            }
-            set
-            {
-                modifyDate = value;
-            }
-        }
-
-        private int startSetc = Sector.ENDOFCHAIN;
-        public int StartSetc
-        {
-            get
-            {
-                return startSetc;
-            }
-            set
-            {
-                startSetc = value;
-            }
-        }
-
-        private long size;
-        public long Size
-        {
-            get
-            {
-                return size;
-            }
-            set
-            {
-                size = value;
-            }
-        }
+        public long Size { get; set; }
 
         public int CompareTo(object obj)
         {
@@ -314,26 +217,26 @@ namespace OpenMcdf
 
         public override int GetHashCode()
         {
-            return (int)fnv_hash(this.entryName);
+            return (int)fnv_hash(this.EntryName);
         }
 
         public void Write(Stream stream)
         {
             StreamRW rw = new StreamRW(stream);
 
-            rw.Write(entryName);
+            rw.Write(EntryName);
             rw.Write(nameLength);
-            rw.Write((byte)stgType);
-            rw.Write((byte)stgColor);
-            rw.Write(leftSibling);
-            rw.Write(rightSibling);
-            rw.Write(child);
+            rw.Write((byte)StgType);
+            rw.Write((byte)StgColor);
+            rw.Write(LeftSibling);
+            rw.Write(RightSibling);
+            rw.Write(Child);
             rw.Write(storageCLSID.ToByteArray());
-            rw.Write(stateBits);
-            rw.Write(creationDate);
-            rw.Write(modifyDate);
-            rw.Write(startSetc);
-            rw.Write(size);
+            rw.Write(StateBits);
+            rw.Write(CreationDate);
+            rw.Write(ModifyDate);
+            rw.Write(StartSetc);
+            rw.Write(Size);
 
             rw.Close();
         }
@@ -369,40 +272,40 @@ namespace OpenMcdf
         {
             StreamRW rw = new StreamRW(stream);
 
-            entryName = rw.ReadBytes(64);
+            EntryName = rw.ReadBytes(64);
             nameLength = rw.ReadUInt16();
-            stgType = (StgType)rw.ReadByte();
+            StgType = (StgType)rw.ReadByte();
             //rw.ReadByte();//Ignore color, only black tree
-            stgColor = (StgColor)rw.ReadByte();
-            leftSibling = rw.ReadInt32();
-            rightSibling = rw.ReadInt32();
-            child = rw.ReadInt32();
+            StgColor = (StgColor)rw.ReadByte();
+            LeftSibling = rw.ReadInt32();
+            RightSibling = rw.ReadInt32();
+            Child = rw.ReadInt32();
 
             // Thanks to bugaccount (BugTrack id 3519554)
-            if (stgType == StgType.StgInvalid)
+            if (StgType == StgType.StgInvalid)
             {
-                leftSibling = NOSTREAM;
-                rightSibling = NOSTREAM;
-                child = NOSTREAM;
+                LeftSibling = NOSTREAM;
+                RightSibling = NOSTREAM;
+                Child = NOSTREAM;
             }
 
             storageCLSID = new Guid(rw.ReadBytes(16));
-            stateBits = rw.ReadInt32();
-            creationDate = rw.ReadBytes(8);
-            modifyDate = rw.ReadBytes(8);
-            startSetc = rw.ReadInt32();
+            StateBits = rw.ReadInt32();
+            CreationDate = rw.ReadBytes(8);
+            ModifyDate = rw.ReadBytes(8);
+            StartSetc = rw.ReadInt32();
 
             if (ver == CFSVersion.Ver_3)
             {
                 // avoid dirty read for version 3 files (max size: 32bit integer)
                 // where most significant bits are not initialized to zero
 
-                size = rw.ReadInt32();
+                Size = rw.ReadInt32();
                 rw.ReadBytes(4); //discard most significant 4 (possibly) dirty bytes
             }
             else
             {
-                size = rw.ReadInt64();
+                Size = rw.ReadInt64();
             }
         }
 
@@ -412,17 +315,17 @@ namespace OpenMcdf
         {
             get
             {
-                if (leftSibling == NOSTREAM)
+                if (LeftSibling == NOSTREAM)
                     return null;
 
-                return dirRepository[leftSibling];
+                return dirRepository[LeftSibling];
             }
             set
             {
-                leftSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
+                LeftSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
 
-                if (leftSibling != NOSTREAM)
-                    dirRepository[leftSibling].Parent = this;
+                if (LeftSibling != NOSTREAM)
+                    dirRepository[LeftSibling].Parent = this;
             }
         }
 
@@ -430,17 +333,17 @@ namespace OpenMcdf
         {
             get
             {
-                if (rightSibling == NOSTREAM)
+                if (RightSibling == NOSTREAM)
                     return null;
 
-                return dirRepository[rightSibling];
+                return dirRepository[RightSibling];
             }
             set
             {
-                rightSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
+                RightSibling = value != null ? ((IDirectoryEntry)value).SID : NOSTREAM;
 
-                if (rightSibling != NOSTREAM)
-                    dirRepository[rightSibling].Parent = this;
+                if (RightSibling != NOSTREAM)
+                    dirRepository[RightSibling].Parent = this;
             }
         }
 
@@ -540,7 +443,7 @@ namespace OpenMcdf
 
         public override string ToString()
         {
-            return this.Name + " [" + this.sid + "]" + (this.stgType == StgType.StgStream ? "Stream" : "Storage");
+            return this.Name + " [" + this.SID + "]" + (this.StgType == StgType.StgStream ? "Stream" : "Storage");
         }
 
         public void AssignValueTo(RedBlackTree.IRBNode other)
@@ -549,16 +452,16 @@ namespace OpenMcdf
 
             d.SetEntryName(this.GetEntryName());
 
-            d.creationDate = new byte[this.creationDate.Length];
-            this.creationDate.CopyTo(d.creationDate, 0);
+            d.CreationDate = new byte[this.CreationDate.Length];
+            this.CreationDate.CopyTo(d.CreationDate, 0);
 
-            d.modifyDate = new byte[this.modifyDate.Length];
-            this.modifyDate.CopyTo(d.modifyDate, 0);
+            d.ModifyDate = new byte[this.ModifyDate.Length];
+            this.ModifyDate.CopyTo(d.ModifyDate, 0);
 
-            d.size = this.size;
-            d.startSetc = this.startSetc;
-            d.stateBits = this.stateBits;
-            d.stgType = this.stgType;
+            d.Size = this.Size;
+            d.StartSetc = this.StartSetc;
+            d.StateBits = this.StateBits;
+            d.StgType = this.StgType;
             d.storageCLSID = new Guid(this.storageCLSID.ToByteArray());
             d.Child = this.Child;
         }

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -33,7 +33,7 @@ namespace OpenMcdf
     {
         internal const int THIS_IS_GREATER = 1;
         internal const int OTHER_IS_GREATER = -1;
-        private IList<IDirectoryEntry> dirRepository;
+        private readonly IList<IDirectoryEntry> dirRepository;
 
         public int SID { get; set; } = -1;
 

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -96,10 +96,8 @@ namespace OpenMcdf
 
                 if (entryName.Length > 31)
                     throw new CFException("Entry name MUST NOT exceed 31 characters");
-
-                byte[] newName = null;
                 byte[] temp = Encoding.Unicode.GetBytes(entryName);
-                newName = new byte[64];
+                byte[] newName = new byte[64];
                 Buffer.BlockCopy(temp, 0, newName, 0, temp.Length);
                 newName[temp.Length] = 0x00;
                 newName[temp.Length + 1] = 0x00;
@@ -393,7 +391,7 @@ namespace OpenMcdf
 
         internal static IDirectoryEntry New(string name, StgType stgType, IList<IDirectoryEntry> dirRepository)
         {
-            DirectoryEntry de = null;
+            DirectoryEntry de;
             if (dirRepository != null)
             {
                 de = new DirectoryEntry(name, stgType, dirRepository);

--- a/sources/OpenMcdf/Header.cs
+++ b/sources/OpenMcdf/Header.cs
@@ -12,142 +12,44 @@ namespace OpenMcdf
 {
     internal sealed class Header
     {
-        //0 8 Compound document file identifier: D0H CFH 11H E0H A1H B1H 1AH E1H
-        private byte[] headerSignature
-            = new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
+        public byte[] HeaderSignature { get; private set; } = new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
 
-        public byte[] HeaderSignature => headerSignature;
+        public byte[] CLSID { get; set; } = new byte[16];
 
-        //8 16 Unique identifier (UID) of this file (not of interest in the following, may be all 0)
-        private byte[] clsid = new byte[16];
+        public ushort MinorVersion { get; private set; } = 0x003E;
 
-        public byte[] CLSID
-        {
-            get { return clsid; }
-            set { clsid = value; }
-        }
+        public ushort MajorVersion { get; private set; } = 0x0003;
 
-        //24 2 Revision number of the file format (most used is 003EH)
-        private ushort minorVersion = 0x003E;
+        public ushort ByteOrder { get; private set; } = 0xFFFE;
 
-        public ushort MinorVersion => minorVersion;
+        public ushort SectorShift { get; private set; } = 9;
 
-        //26 2 Version number of the file format (most used is 0003H)
-        private ushort majorVersion = 0x0003;
+        public ushort MiniSectorShift { get; private set; } = 6;
 
-        public ushort MajorVersion => majorVersion;
+        public byte[] UnUsed { get; private set; } = new byte[6];
 
-        //28 2 Byte order identifier (➜4.2): FEH FFH = Little-Endian FFH FEH = Big-Endian
-        private ushort byteOrder = 0xFFFE;
+        public int DirectorySectorsNumber { get; set; }
 
-        public ushort ByteOrder => byteOrder;
+        public int FATSectorsNumber { get; set; }
 
-        //30 2 Size of a sector in the compound document file (➜3.1) in power-of-two (ssz), real sector
-        //size is sec_size = 2ssz bytes (minimum value is 7 which means 128 bytes, most used
-        //value is 9 which means 512 bytes)
-        private ushort sectorShift = 9;
+        public int FirstDirectorySectorID { get; set; } = Sector.ENDOFCHAIN;
 
-        public ushort SectorShift => sectorShift;
+        public uint UnUsed2 { get; private set; }
 
-        //32 2 Size of a short-sector in the short-stream container stream (➜6.1) in power-of-two (sssz),
-        //real short-sector size is short_sec_size = 2sssz bytes (maximum value is sector size
-        //ssz, see above, most used value is 6 which means 64 bytes)
-        private ushort miniSectorShift = 6;
-        public ushort MiniSectorShift => miniSectorShift;
-
-        //34 10 Not used
-        private byte[] unUsed = new byte[6];
-
-        public byte[] UnUsed => unUsed;
-
-        //44 4 Total number of sectors used Directory (➜5.2)
-        private int directorySectorsNumber;
-
-        public int DirectorySectorsNumber
-        {
-            get { return directorySectorsNumber; }
-            set { directorySectorsNumber = value; }
-        }
-
-        //44 4 Total number of sectors used for the sector allocation table (➜5.2)
-        private int fatSectorsNumber;
-
-        public int FATSectorsNumber
-        {
-            get { return fatSectorsNumber; }
-            set { fatSectorsNumber = value; }
-        }
-
-        //48 4 SecID of first sector of the directory stream (➜7)
-        private int firstDirectorySectorID = Sector.ENDOFCHAIN;
-
-        public int FirstDirectorySectorID
-        {
-            get { return firstDirectorySectorID; }
-            set { firstDirectorySectorID = value; }
-        }
-
-        //52 4 Not used
-        private uint unUsed2;
-
-        public uint UnUsed2 => unUsed2;
-
-        //56 4 Minimum size of a standard stream (in bytes, minimum allowed and most used size is 4096
-        //bytes), streams with an actual size smaller than (and not equal to) this value are stored as
-        //short-streams (➜6)
-        private uint minSizeStandardStream = 4096;
-
-        public uint MinSizeStandardStream
-        {
-            get { return minSizeStandardStream; }
-            set { minSizeStandardStream = value; }
-        }
-
-        //60 4 SecID of first sector of the short-sector allocation table (➜6.2), or –2 (End Of Chain
-        //SecID, ➜3.1) if not extant
-        private int firstMiniFATSectorID = unchecked((int)0xFFFFFFFE);
+        public uint MinSizeStandardStream { get; set; } = 4096;
 
         /// <summary>
         /// This integer field contains the starting sector number for the mini FAT
         /// </summary>
-        public int FirstMiniFATSectorID
-        {
-            get { return firstMiniFATSectorID; }
-            set { firstMiniFATSectorID = value; }
-        }
+        public int FirstMiniFATSectorID { get; set; } = unchecked((int)0xFFFFFFFE);
 
-        //64 4 Total number of sectors used for the short-sector allocation table (➜6.2)
-        private uint miniFATSectorsNumber;
+        public uint MiniFATSectorsNumber { get; set; }
 
-        public uint MiniFATSectorsNumber
-        {
-            get { return miniFATSectorsNumber; }
-            set { miniFATSectorsNumber = value; }
-        }
+        public int FirstDIFATSectorID { get; set; } = Sector.ENDOFCHAIN;
 
-        //68 4 SecID of first sector of the master sector allocation table (➜5.1), or –2 (End Of Chain
-        //SecID, ➜3.1) if no additional sectors used
-        private int firstDIFATSectorID = Sector.ENDOFCHAIN;
+        public uint DIFATSectorsNumber { get; set; }
 
-        public int FirstDIFATSectorID
-        {
-            get { return firstDIFATSectorID; }
-            set { firstDIFATSectorID = value; }
-        }
-
-        //72 4 Total number of sectors used for the master sector allocation table (➜5.1)
-        private uint difatSectorsNumber;
-
-        public uint DIFATSectorsNumber
-        {
-            get { return difatSectorsNumber; }
-            set { difatSectorsNumber = value; }
-        }
-
-        //76 436 First part of the master sector allocation table (➜5.1) containing 109 SecIDs
-        private int[] difat = new int[109];
-
-        public int[] DIFAT => difat;
+        public int[] DIFAT { get; } = new int[109];
 
         public Header()
             : this(3)
@@ -159,13 +61,13 @@ namespace OpenMcdf
             switch (version)
             {
                 case 3:
-                    this.majorVersion = 3;
-                    this.sectorShift = 0x0009;
+                    this.MajorVersion = 3;
+                    this.SectorShift = 0x0009;
                     break;
 
                 case 4:
-                    this.majorVersion = 4;
-                    this.sectorShift = 0x000C;
+                    this.MajorVersion = 4;
+                    this.SectorShift = 0x000C;
                     break;
 
                 default:
@@ -174,7 +76,7 @@ namespace OpenMcdf
 
             for (int i = 0; i < 109; i++)
             {
-                difat[i] = Sector.FREESECT;
+                DIFAT[i] = Sector.FREESECT;
             }
         }
 
@@ -182,30 +84,30 @@ namespace OpenMcdf
         {
             StreamRW rw = new StreamRW(stream);
 
-            rw.Write(headerSignature);
-            rw.Write(clsid);
-            rw.Write(minorVersion);
-            rw.Write(majorVersion);
-            rw.Write(byteOrder);
-            rw.Write(sectorShift);
-            rw.Write(miniSectorShift);
-            rw.Write(unUsed);
-            rw.Write(directorySectorsNumber);
-            rw.Write(fatSectorsNumber);
-            rw.Write(firstDirectorySectorID);
-            rw.Write(unUsed2);
-            rw.Write(minSizeStandardStream);
-            rw.Write(firstMiniFATSectorID);
-            rw.Write(miniFATSectorsNumber);
-            rw.Write(firstDIFATSectorID);
-            rw.Write(difatSectorsNumber);
+            rw.Write(HeaderSignature);
+            rw.Write(CLSID);
+            rw.Write(MinorVersion);
+            rw.Write(MajorVersion);
+            rw.Write(ByteOrder);
+            rw.Write(SectorShift);
+            rw.Write(MiniSectorShift);
+            rw.Write(UnUsed);
+            rw.Write(DirectorySectorsNumber);
+            rw.Write(FATSectorsNumber);
+            rw.Write(FirstDirectorySectorID);
+            rw.Write(UnUsed2);
+            rw.Write(MinSizeStandardStream);
+            rw.Write(FirstMiniFATSectorID);
+            rw.Write(MiniFATSectorsNumber);
+            rw.Write(FirstDIFATSectorID);
+            rw.Write(DIFATSectorsNumber);
 
-            foreach (int i in difat)
+            foreach (int i in DIFAT)
             {
                 rw.Write(i);
             }
 
-            if (majorVersion == 4)
+            if (MajorVersion == 4)
             {
                 byte[] zeroHead = new byte[3584];
                 rw.Write(zeroHead);
@@ -218,25 +120,25 @@ namespace OpenMcdf
         {
             StreamRW rw = new StreamRW(stream);
 
-            headerSignature = rw.ReadBytes(8);
+            HeaderSignature = rw.ReadBytes(8);
             CheckSignature();
-            clsid = rw.ReadBytes(16);
-            minorVersion = rw.ReadUInt16();
-            majorVersion = rw.ReadUInt16();
+            CLSID = rw.ReadBytes(16);
+            MinorVersion = rw.ReadUInt16();
+            MajorVersion = rw.ReadUInt16();
             CheckVersion();
-            byteOrder = rw.ReadUInt16();
-            sectorShift = rw.ReadUInt16();
-            miniSectorShift = rw.ReadUInt16();
-            unUsed = rw.ReadBytes(6);
-            directorySectorsNumber = rw.ReadInt32();
-            fatSectorsNumber = rw.ReadInt32();
-            firstDirectorySectorID = rw.ReadInt32();
-            unUsed2 = rw.ReadUInt32();
-            minSizeStandardStream = rw.ReadUInt32();
-            firstMiniFATSectorID = rw.ReadInt32();
-            miniFATSectorsNumber = rw.ReadUInt32();
-            firstDIFATSectorID = rw.ReadInt32();
-            difatSectorsNumber = rw.ReadUInt32();
+            ByteOrder = rw.ReadUInt16();
+            SectorShift = rw.ReadUInt16();
+            MiniSectorShift = rw.ReadUInt16();
+            UnUsed = rw.ReadBytes(6);
+            DirectorySectorsNumber = rw.ReadInt32();
+            FATSectorsNumber = rw.ReadInt32();
+            FirstDirectorySectorID = rw.ReadInt32();
+            UnUsed2 = rw.ReadUInt32();
+            MinSizeStandardStream = rw.ReadUInt32();
+            FirstMiniFATSectorID = rw.ReadInt32();
+            MiniFATSectorsNumber = rw.ReadUInt32();
+            FirstDIFATSectorID = rw.ReadInt32();
+            DIFATSectorsNumber = rw.ReadUInt32();
 
             for (int i = 0; i < 109; i++)
             {
@@ -248,7 +150,7 @@ namespace OpenMcdf
 
         private void CheckVersion()
         {
-            if (this.majorVersion != 3 && this.majorVersion != 4)
+            if (this.MajorVersion != 3 && this.MajorVersion != 4)
                 throw new CFFileFormatException("Unsupported Binary File Format version: OpenMcdf only supports Compound Files with major version equal to 3 or 4 ");
         }
 
@@ -259,9 +161,9 @@ namespace OpenMcdf
 
         private void CheckSignature()
         {
-            for (int i = 0; i < headerSignature.Length; i++)
+            for (int i = 0; i < HeaderSignature.Length; i++)
             {
-                if (headerSignature[i] != OLE_CFS_SIGNATURE[i])
+                if (HeaderSignature[i] != OLE_CFS_SIGNATURE[i])
                     throw new CFFileFormatException("Invalid OLE structured storage file");
             }
         }

--- a/sources/OpenMcdf/Header.cs
+++ b/sources/OpenMcdf/Header.cs
@@ -157,7 +157,7 @@ namespace OpenMcdf
         /// <summary>
         /// Structured Storage signature
         /// </summary>
-        private byte[] OLE_CFS_SIGNATURE = new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
+        private readonly byte[] OLE_CFS_SIGNATURE = new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
 
         private void CheckSignature()
         {

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -356,7 +356,7 @@ namespace RedBlackTree
             }
 
             //assert n.left == null || n.right == null;
-            IRBNode child = (n.Right == null) ? n.Left : n.Right;
+            IRBNode child = n.Right ?? n.Left;
             if (NodeColor(n) == Color.BLACK)
             {
                 n.Color = NodeColor(child);

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -33,8 +33,11 @@ namespace RedBlackTree
         }
     }
 
-    public enum Color { RED = 0,
-        BLACK = 1 }
+    public enum Color
+    {
+        RED = 0,
+        BLACK = 1
+    }
 
     /// <summary>
     /// Red Black Node interface

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -513,7 +513,7 @@ namespace RedBlackTree
         public class RBTreeEnumerator : IEnumerator<IRBNode>
         {
             int position = -1;
-            private Queue<IRBNode> heap = new Queue<IRBNode>();
+            private readonly Queue<IRBNode> heap = new Queue<IRBNode>();
 
             internal RBTreeEnumerator(RBTree tree)
             {
@@ -545,7 +545,7 @@ namespace RedBlackTree
             return new RBTreeEnumerator(this);
         }
 
-        private static int INDENT_STEP = 15;
+        private static readonly int INDENT_STEP = 15;
 
         public void Print()
         {

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -252,10 +252,7 @@ namespace RedBlackTree
 
             InsertCase1(insertedNode);
 
-            if (NodeInserted != null)
-            {
-                NodeInserted(insertedNode);
-            }
+            NodeInserted?.Invoke(insertedNode);
 
             //Trace.WriteLine(" ");
             //Print();
@@ -482,8 +479,7 @@ namespace RedBlackTree
                 DoVisitTree(action, walker.Left);
             }
 
-            if (action != null)
-                action(walker);
+            action?.Invoke(walker);
 
             if (walker.Right != null)
             {
@@ -507,8 +503,7 @@ namespace RedBlackTree
                 DoVisitTreeNodes(action, walker.Left);
             }
 
-            if (action != null)
-                action(walker);
+            action?.Invoke(walker);
 
             if (walker.Right != null)
             {
@@ -586,8 +581,7 @@ namespace RedBlackTree
 
         internal void FireNodeOperation(IRBNode node, NodeOperation operation)
         {
-            if (NodeOperation != null)
-                NodeOperation(node, operation);
+            NodeOperation?.Invoke(node, operation);
         }
 
         //internal void FireValueAssigned(RBNode<V> node, V value)

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -340,7 +340,6 @@ namespace RedBlackTree
         {
             deletedAlt = null;
             IRBNode n = LookupNode(template);
-            template = n;
             if (n == null)
                 return;  // Key not found, do nothing
             if (n.Left != null && n.Right != null)

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -30,59 +30,37 @@ namespace OpenMcdf
         public const int FATSECT = unchecked((int)0xFFFFFFFD);
         public const int DIFSECT = unchecked((int)0xFFFFFFFC);
 
-        private bool dirtyFlag = false;
+        public bool DirtyFlag { get; set; } = false;
 
-        public bool DirtyFlag
-        {
-            get { return dirtyFlag; }
-            set { dirtyFlag = value; }
-        }
+        public bool IsStreamed => (stream != null && Size != MINISECTOR_SIZE) ? (this.Id * Size) + Size < stream.Length : false;
 
-        public bool IsStreamed => (stream != null && size != MINISECTOR_SIZE) ? (this.id * size) + size < stream.Length : false;
-
-        private int size = 0;
         private Stream stream;
 
         public Sector(int size, Stream stream)
         {
-            this.size = size;
+            this.Size = size;
             this.stream = stream;
         }
 
         public Sector(int size, byte[] data)
         {
-            this.size = size;
+            this.Size = size;
             this.data = data;
             this.stream = null;
         }
 
         public Sector(int size)
         {
-            this.size = size;
+            this.Size = size;
             this.data = null;
             this.stream = null;
         }
 
-        private SectorType type;
+        internal SectorType Type { get; set; }
 
-        internal SectorType Type
-        {
-            get { return type; }
-            set { type = value; }
-        }
+        public int Id { get; set; } = -1;
 
-        private int id = -1;
-
-        public int Id
-        {
-            get { return id; }
-            set
-            {
-                id = value;
-            }
-        }
-
-        public int Size => size;
+        public int Size { get; private set; } = 0;
 
         private byte[] data;
 
@@ -90,12 +68,12 @@ namespace OpenMcdf
         {
             if (this.data == null)
             {
-                data = new byte[size];
+                data = new byte[Size];
 
                 if (IsStreamed)
                 {
-                    stream.Seek(size + id * (long)size, SeekOrigin.Begin);
-                    stream.Read(data, 0, size);
+                    stream.Seek(Size + Id * (long)Size, SeekOrigin.Begin);
+                    stream.Read(data, 0, Size);
                 }
             }
 
@@ -120,18 +98,18 @@ namespace OpenMcdf
 
         public void ZeroData()
         {
-            data = new byte[size];
-            dirtyFlag = true;
+            data = new byte[Size];
+            DirtyFlag = true;
         }
 
         public void InitFATData()
         {
-            data = new byte[size];
+            data = new byte[Size];
 
-            for (int i = 0; i < size; i++)
+            for (int i = 0; i < Size; i++)
                 data[i] = 0xFF;
 
-            dirtyFlag = true;
+            DirtyFlag = true;
         }
 
         internal void ReleaseData()
@@ -154,9 +132,9 @@ namespace OpenMcdf
                     lock (lockObject)
                     {
                         this.data = null;
-                        this.dirtyFlag = false;
-                        this.id = ENDOFCHAIN;
-                        this.size = 0;
+                        this.DirtyFlag = false;
+                        this.Id = ENDOFCHAIN;
+                        this.Size = 0;
                     }
                 }
             }

--- a/sources/OpenMcdf/Sector.cs
+++ b/sources/OpenMcdf/Sector.cs
@@ -34,7 +34,7 @@ namespace OpenMcdf
 
         public bool IsStreamed => (stream != null && Size != MINISECTOR_SIZE) ? (this.Id * Size) + Size < stream.Length : false;
 
-        private Stream stream;
+        private readonly Stream stream;
 
         public Sector(int size, Stream stream)
         {
@@ -117,7 +117,7 @@ namespace OpenMcdf
             this.data = null;
         }
 
-        private object lockObject = new object();
+        private readonly object lockObject = new object();
 
         #region IDisposable Members
 

--- a/sources/OpenMcdf/SectorCollection.cs
+++ b/sources/OpenMcdf/SectorCollection.cs
@@ -30,7 +30,7 @@ namespace OpenMcdf
 
         public event Ver3SizeLimitReached OnVer3SizeLimitReached;
 
-        private List<ArrayList> largeArraySlices = new List<ArrayList>();
+        private readonly List<ArrayList> largeArraySlices = new List<ArrayList>();
 
         public SectorCollection()
         {

--- a/sources/OpenMcdf/SectorCollection.cs
+++ b/sources/OpenMcdf/SectorCollection.cs
@@ -28,8 +28,6 @@ namespace OpenMcdf
         private const int MAX_SECTOR_V4_COUNT_LOCK_RANGE = 524287; //0x7FFFFF00 for Version 4
         private const int SLICE_SIZE = 4096;
 
-        private int count = 0;
-
         public event Ver3SizeLimitReached OnVer3SizeLimitReached;
 
         private List<ArrayList> largeArraySlices = new List<ArrayList>();
@@ -41,7 +39,7 @@ namespace OpenMcdf
         private bool sizeLimitReached = false;
         private void DoCheckSizeLimitReached()
         {
-            if (OnVer3SizeLimitReached != null && !sizeLimitReached && (count - 1 > MAX_SECTOR_V4_COUNT_LOCK_RANGE))
+            if (OnVer3SizeLimitReached != null && !sizeLimitReached && (Count - 1 > MAX_SECTOR_V4_COUNT_LOCK_RANGE))
             {
                 sizeLimitReached = true;
                 OnVer3SizeLimitReached();
@@ -72,7 +70,7 @@ namespace OpenMcdf
                 int itemIndex = index / SLICE_SIZE;
                 int itemOffset = index % SLICE_SIZE;
 
-                if ((index > -1) && (index < count))
+                if ((index > -1) && (index < Count))
                 {
                     return (Sector)largeArraySlices[itemIndex][itemOffset];
                 }
@@ -85,7 +83,7 @@ namespace OpenMcdf
                 int itemIndex = index / SLICE_SIZE;
                 int itemOffset = index % SLICE_SIZE;
 
-                if (index > -1 && index < count)
+                if (index > -1 && index < Count)
                 {
                     largeArraySlices[itemIndex][itemOffset] = value;
                 }
@@ -100,22 +98,22 @@ namespace OpenMcdf
 
         private int add(Sector item)
         {
-            int itemIndex = count / SLICE_SIZE;
+            int itemIndex = Count / SLICE_SIZE;
 
             if (itemIndex < largeArraySlices.Count)
             {
                 largeArraySlices[itemIndex].Add(item);
-                count++;
+                Count++;
             }
             else
             {
                 ArrayList ar = new ArrayList(SLICE_SIZE);
                 ar.Add(item);
                 largeArraySlices.Add(ar);
-                count++;
+                Count++;
             }
 
-            return count - 1;
+            return Count - 1;
         }
 
         public void Add(Sector item)
@@ -134,7 +132,7 @@ namespace OpenMcdf
 
             largeArraySlices.Clear();
 
-            count = 0;
+            Count = 0;
         }
 
         public bool Contains(Sector item)
@@ -147,7 +145,7 @@ namespace OpenMcdf
             throw new NotImplementedException();
         }
 
-        public int Count => count;
+        public int Count { get; private set; } = 0;
 
         public bool IsReadOnly => false;
 

--- a/sources/OpenMcdf/StreamRW.cs
+++ b/sources/OpenMcdf/StreamRW.cs
@@ -12,8 +12,8 @@ namespace OpenMcdf
 {
     internal sealed class StreamRW
     {
-        private byte[] buffer = new byte[8];
-        private Stream stream;
+        private readonly byte[] buffer = new byte[8];
+        private readonly Stream stream;
 
         public StreamRW(Stream stream)
         {

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -17,12 +17,12 @@ namespace OpenMcdf
     /// </summary>
     internal sealed class StreamView : Stream
     {
-        private int sectorSize;
+        private readonly int sectorSize;
 
         private long position;
-        private Stream stream;
-        private bool isFatStream = false;
-        private List<Sector> freeSectors = new List<Sector>();
+        private readonly Stream stream;
+        private readonly bool isFatStream = false;
+        private readonly List<Sector> freeSectors = new List<Sector>();
         public IEnumerable<Sector> FreeSectors => freeSectors;
 
         public StreamView(List<Sector> sectorChain, int sectorSize, Stream stream)
@@ -82,7 +82,7 @@ namespace OpenMcdf
             base.Close();
         }
 
-        private byte[] buf = new byte[4];
+        private readonly byte[] buf = new byte[4];
 
         public int ReadInt32()
         {

--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -93,7 +93,6 @@ namespace OpenMcdf
         public override int Read(byte[] buffer, int offset, int count)
         {
             int nRead = 0;
-            int nToRead = 0;
 
             // Don't try to read more bytes than this stream contains.
             long intMax = Math.Min(int.MaxValue, this.length);
@@ -107,7 +106,7 @@ namespace OpenMcdf
                 // Bytes to read count is the min between request count
                 // and sector border
 
-                nToRead = Math.Min(
+                int nToRead = Math.Min(
                     BaseSectorChain[0].Size - ((int)position % sectorSize),
                     count);
 
@@ -208,8 +207,7 @@ namespace OpenMcdf
 
                 while (nSec > 0)
                 {
-                    Sector t = null;
-
+                    Sector t;
                     if (availableSectors == null || availableSectors.Count == 0)
                     {
                         t = new Sector(sectorSize, stream);
@@ -272,7 +270,6 @@ namespace OpenMcdf
         public override void Write(byte[] buffer, int offset, int count)
         {
             int byteWritten = 0;
-            int roundByteWritten = 0;
 
             // Assure length
             if ((position + count) > length)
@@ -284,7 +281,7 @@ namespace OpenMcdf
                 int secOffset = (int)(position / sectorSize);
                 int secShift = (int)(position % sectorSize);
 
-                roundByteWritten = Math.Min(sectorSize - (int)(position % sectorSize), count);
+                int roundByteWritten = Math.Min(sectorSize - (int)(position % sectorSize), count);
 
                 if (secOffset < BaseSectorChain.Count)
                 {
@@ -334,9 +331,6 @@ namespace OpenMcdf
                         roundByteWritten);
 
                     BaseSectorChain[secOffset].DirtyFlag = true;
-
-                    offset += roundByteWritten;
-                    byteWritten += roundByteWritten;
                 }
 
                 position += count;

--- a/sources/Structured Storage Explorer/MainForm.cs
+++ b/sources/Structured Storage Explorer/MainForm.cs
@@ -104,9 +104,7 @@ namespace StructuredStorageExplorer
         private void RefreshTree()
         {
             treeView1.Nodes.Clear();
-
-            TreeNode root = null;
-            root = treeView1.Nodes.Add("Root Entry", "Root");
+            TreeNode root = treeView1.Nodes.Add("Root Entry", "Root");
             root.ImageIndex = 0;
             root.Tag = cf.RootStorage;
 
@@ -249,7 +247,6 @@ namespace StructuredStorageExplorer
                     {
                         fs.Flush();
                         fs.Close();
-                        fs = null;
                     }
                 }
             }
@@ -334,8 +331,6 @@ namespace StructuredStorageExplorer
 
         private void importDataStripMenuItem1_Click(object sender, EventArgs e)
         {
-            string fileName = string.Empty;
-
             if (openDataFileDialog.ShowDialog() == DialogResult.OK)
             {
                 CFStream s = treeView1.SelectedNode.Tag as CFStream;

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -38,8 +38,7 @@ namespace StructuredStorageExplorer
         {
             _hasChanges = true;
 
-            if (Changed != null)
-                Changed(this, e);
+            Changed?.Invoke(this, e);
         }
 
         /// <summary>
@@ -47,8 +46,7 @@ namespace StructuredStorageExplorer
         /// </summary>
         void OnLengthChanged(EventArgs e)
         {
-            if (LengthChanged != null)
-                LengthChanged(this, e);
+            LengthChanged?.Invoke(this, e);
         }
 
         /// <summary>

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -17,17 +17,12 @@ namespace StructuredStorageExplorer
         bool _hasChanges;
 
         /// <summary>
-        /// Contains a byte collection.
-        /// </summary>
-        ByteCollection _bytes;
-
-        /// <summary>
         /// Initializes a new instance of the DynamicByteProvider class.
         /// </summary>
         /// <param name="bytes"></param>
         public StreamDataProvider(CFStream modifiedStream)
         {
-            _bytes = new ByteCollection(modifiedStream.GetData());
+            Bytes = new ByteCollection(modifiedStream.GetData());
             _modifiedStream = modifiedStream;
         }
 
@@ -52,7 +47,7 @@ namespace StructuredStorageExplorer
         /// <summary>
         /// Gets the byte collection.
         /// </summary>
-        public ByteCollection Bytes => _bytes;
+        public ByteCollection Bytes { get; }
 
         #region IByteProvider Members
         /// <summary>
@@ -70,7 +65,7 @@ namespace StructuredStorageExplorer
         {
             _hasChanges = false;
 
-            _modifiedStream.SetData(this._bytes.ToArray());
+            _modifiedStream.SetData(this.Bytes.ToArray());
         }
 
         /// <summary>
@@ -89,7 +84,7 @@ namespace StructuredStorageExplorer
         /// <param name="index">the index of the byte to read</param>
         /// <returns>the byte</returns>
         public byte ReadByte(long index)
-        { return _bytes[(int)index]; }
+        { return Bytes[(int)index]; }
 
         /// <summary>
         /// Write a byte into the byte collection.
@@ -98,7 +93,7 @@ namespace StructuredStorageExplorer
         /// <param name="value">the byte</param>
         public void WriteByte(long index, byte value)
         {
-            _bytes[(int)index] = value;
+            Bytes[(int)index] = value;
             OnChanged(EventArgs.Empty);
         }
 
@@ -111,7 +106,7 @@ namespace StructuredStorageExplorer
         {
             int internal_index = (int)Math.Max(0, index);
             int internal_length = (int)Math.Min((int)Length, length);
-            _bytes.RemoveRange(internal_index, internal_length);
+            Bytes.RemoveRange(internal_index, internal_length);
 
             OnLengthChanged(EventArgs.Empty);
             OnChanged(EventArgs.Empty);
@@ -124,7 +119,7 @@ namespace StructuredStorageExplorer
         /// <param name="bs">the byte array to insert</param>
         public void InsertBytes(long index, byte[] bs)
         {
-            _bytes.InsertRange((int)index, bs);
+            Bytes.InsertRange((int)index, bs);
 
             OnLengthChanged(EventArgs.Empty);
             OnChanged(EventArgs.Empty);
@@ -133,7 +128,7 @@ namespace StructuredStorageExplorer
         /// <summary>
         /// Gets the length of the bytes in the byte collection.
         /// </summary>
-        public long Length => _bytes.Count;
+        public long Length => Bytes.Count;
 
         /// <summary>
         /// Returns true

--- a/sources/Structured Storage Explorer/StreamDataProvider.cs
+++ b/sources/Structured Storage Explorer/StreamDataProvider.cs
@@ -9,7 +9,7 @@ namespace StructuredStorageExplorer
         /// <summary>
         /// Modifying stream
         /// </summary>
-        CFStream _modifiedStream;
+        readonly CFStream _modifiedStream;
 
         /// <summary>
         /// Contains information about changes.

--- a/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/CFSStreamExtensionsTest.cs
@@ -15,23 +15,11 @@ namespace OpenMcdf.Extensions.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -18,23 +18,11 @@ namespace OpenMcdf.Extensions.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.PerfTest/Program.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Program.cs
@@ -5,8 +5,8 @@ namespace OpenMcdf.PerfTest
 {
     class Program
     {
-        static int MAX_STREAM_COUNT = 5000;
-        static string fileName = "PerfLoad.cfs";
+        static readonly int MAX_STREAM_COUNT = 5000;
+        static readonly string fileName = "PerfLoad.cfs";
 
         static void Main(string[] args)
         {

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -759,12 +759,10 @@ namespace OpenMcdf.Test
         {
             int INITIAL_SIZE = 1024 * 1024 * 2;
             int DELTA_SIZE = 300;
-
-            CompoundFile cf = null;
             //CFStream st = null;
             byte[] b = Helpers.GetBuffer(INITIAL_SIZE); //2MB buffer
 
-            cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             cf.RootStorage.AddStream("AStream").SetData(b);
             cf.Save("$Test_RESIZE_STREAM.cfs");
             cf.Close();
@@ -791,8 +789,6 @@ namespace OpenMcdf.Test
         public void Test_RESIZE_STREAM_TRANSITION_TO_MINI()
         {
             string FILE_NAME = "$Test_RESIZE_STREAM_TRANSITION_TO_MINI.cfs";
-            CompoundFile cf = null;
-
             byte[] b = Helpers.GetBuffer(1024 * 1024 * 2); //2MB buffer
             byte[] b100 = new byte[100];
 
@@ -801,7 +797,7 @@ namespace OpenMcdf.Test
                 b100[i] = b[i];
             }
 
-            cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             cf.RootStorage.AddStream("AStream").SetData(b);
             cf.Save(FILE_NAME);
             cf.Close();
@@ -823,10 +819,9 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_RESIZE_STREAM_TRANSITION_TO_NORMAL()
         {
-            CompoundFile cf = null;
             byte[] b = Helpers.GetBuffer(1024 * 2, 0xAA); //2MB buffer
 
-            cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             cf.RootStorage.AddStream("AStream").SetData(b);
             cf.Save("$Test_RESIZE_STREAM_TRANSITION_TO_NORMAL.cfs");
             cf.Save("$Test_RESIZE_STREAM_TRANSITION_TO_NORMAL2.cfs");
@@ -851,13 +846,12 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_RESIZE_MINISTREAM_NO_TRANSITION_MOD()
         {
-            CompoundFile cf = null;
             int INITIAL_SIZE = 1024 * 2;
             int SIZE_DELTA = 148;
 
             byte[] b = Helpers.GetBuffer(INITIAL_SIZE);
 
-            cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             cf.RootStorage.AddStream("MiniStream").SetData(b);
             cf.Save("$Test_RESIZE_MINISTREAM.cfs");
             cf.Close();
@@ -886,11 +880,9 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_RESIZE_MINISTREAM_SECTOR_RECYCLE()
         {
-            CompoundFile cf = null;
-
             byte[] b = Helpers.GetBuffer(1024 * 2);
 
-            cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             cf.RootStorage.AddStream("MiniStream").SetData(b);
             cf.Save("$Test_RESIZE_MINISTREAM_RECYCLE.cfs");
             cf.Close();
@@ -916,14 +908,11 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_DELETE_STREAM_SECTOR_REUSE()
         {
-            CompoundFile cf = null;
-            CFStream st = null;
-
             byte[] b = Helpers.GetBuffer(1024 * 1024 * 2); //2MB buffer
             byte[] cmp = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7 };
 
-            cf = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.Default);
-            st = cf.RootStorage.AddStream("AStream");
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.Default);
+            CFStream st = cf.RootStorage.AddStream("AStream");
             st.Append(b);
             cf.Save("SectorRecycle.cfs");
             cf.Close();

--- a/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSStreamTest.cs
@@ -18,23 +18,11 @@ namespace OpenMcdf.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFSTorageTest.cs
@@ -17,23 +17,11 @@ namespace OpenMcdf.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -625,12 +625,10 @@ namespace OpenMcdf.Test
         public void Test_ADD_LARGE_NUMBER_OF_ITEMS()
         {
             int ITEM_NUMBER = 10000;
-
-            CompoundFile f = null;
             byte[] buffer = Helpers.GetBuffer(10, 0x0A);
             try
             {
-                f = new CompoundFile();
+                CompoundFile f = new CompoundFile();
 
                 for (int i = 0; i < ITEM_NUMBER; i++)
                 {

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -17,23 +17,11 @@ namespace OpenMcdf.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Test/RBTreeTest.cs
+++ b/sources/Test/OpenMcdf.Test/RBTreeTest.cs
@@ -15,23 +15,11 @@ namespace OpenMcdf.Test
         {
         }
 
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
+++ b/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
@@ -10,23 +10,11 @@ namespace OpenMcdf.Test
     [TestClass()]
     public class SectorCollectionTest
     {
-        private TestContext testContextInstance;
-
         /// <summary>
         /// Gets or sets the test context which provides
         /// information about and functionality for the current test run.
         /// </summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
+        public TestContext TestContext { get; set; }
 
         #region Additional test attributes
         //

--- a/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
+++ b/sources/Test/OpenMcdf.Test/SectorCollectionTest.cs
@@ -91,9 +91,6 @@ namespace OpenMcdf.Test
             Assert.AreEqual(expected, actual);
             Assert.IsNotNull(actual);
             Assert.IsTrue(actual.Id == expected.Id);
-
-            actual = null;
-
             try
             {
                 actual = target[count + 100];


### PR DESCRIPTION
These are the last set of analyzer fixes that are reasonable to apply without increasing the C# language version.
From this point, I could start digging into some bug fixes for the 2.x branch more effectively, but it might also be nice to enable C# 10 and do one more round of fixes to gain even better alignment between 2.x and 3.x.