### PR TITLE
Deserialize DateTimes as UTC

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -486,12 +486,12 @@ namespace OpenMcdf.Extensions.OLEProperties
             {
                 long tmp = br.ReadInt64();
 
-                return DateTime.FromFileTime(tmp);
+                return DateTime.FromFileTimeUtc(tmp);
             }
 
             public override void WriteScalarValue(BinaryWriter bw, DateTime pValue)
             {
-                bw.Write(pValue.ToFileTime());
+                bw.Write(pValue.ToFileTimeUtc());
             }
         }
 

--- a/sources/OpenMcdf/CFItem.cs
+++ b/sources/OpenMcdf/CFItem.cs
@@ -165,13 +165,13 @@ namespace OpenMcdf
         {
             get
             {
-                return DateTime.FromFileTime(BitConverter.ToInt64(DirEntry.CreationDate, 0));
+                return DateTime.FromFileTimeUtc(BitConverter.ToInt64(DirEntry.CreationDate, 0));
             }
 
             set
             {
                 if (DirEntry.StgType != StgType.StgStream && DirEntry.StgType != StgType.StgRoot)
-                    DirEntry.CreationDate = BitConverter.GetBytes(value.ToFileTime());
+                    DirEntry.CreationDate = BitConverter.GetBytes(value.ToFileTimeUtc());
                 else
                     throw new CFException("Creation Date can only be set on storage entries");
             }
@@ -184,13 +184,13 @@ namespace OpenMcdf
         {
             get
             {
-                return DateTime.FromFileTime(BitConverter.ToInt64(DirEntry.ModifyDate, 0));
+                return DateTime.FromFileTimeUtc(BitConverter.ToInt64(DirEntry.ModifyDate, 0));
             }
 
             set
             {
                 if (DirEntry.StgType != StgType.StgStream && DirEntry.StgType != StgType.StgRoot)
-                    DirEntry.ModifyDate = BitConverter.GetBytes(value.ToFileTime());
+                    DirEntry.ModifyDate = BitConverter.GetBytes(value.ToFileTimeUtc());
                 else
                     throw new CFException("Modify Date can only be set on storage entries");
             }

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -51,7 +51,7 @@ namespace OpenMcdf
 
             if (stgType == StgType.StgStorage)
             {
-                CreationDate = BitConverter.GetBytes(DateTime.Now.ToFileTime());
+                CreationDate = BitConverter.GetBytes(DateTime.Now.ToFileTimeUtc());
                 StartSetc = ZERO;
             }
 

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -365,7 +365,7 @@ namespace OpenMcdf.Extensions.Test
                 File.Delete("test_add_user_defined_property.doc");
 
             // Test value for a VT_FILETIME property
-            DateTime testNow = DateTime.Now;
+            DateTime testNow = DateTime.UtcNow;
 
             // english.presets.doc has a user defined property section, but no properties other than the codepage
             using (CompoundFile cf = new CompoundFile("english.presets.doc"))

--- a/sources/Test/OpenMcdf.MemTest/Program.cs
+++ b/sources/Test/OpenMcdf.MemTest/Program.cs
@@ -240,7 +240,7 @@ namespace OpenMcdf.MemTest
 
             Random r = new Random();
 
-            DateTime start = DateTime.Now;
+            var stopwatch = Stopwatch.StartNew();
 
             for (int i = 0; i < 1000; i++)
             {
@@ -265,8 +265,7 @@ namespace OpenMcdf.MemTest
 
             cf.Close();
 
-            TimeSpan sp = DateTime.Now - start;
-            Console.WriteLine(sp.TotalMilliseconds);
+            Console.WriteLine($"Elapsed: {stopwatch.Elapsed}");
         }
 
         private static byte[] GetBuffer(int count)

--- a/sources/Test/OpenMcdf.PerfTest/Program.cs
+++ b/sources/Test/OpenMcdf.PerfTest/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace OpenMcdf.PerfTest
@@ -17,10 +18,9 @@ namespace OpenMcdf.PerfTest
             }
 
             CompoundFile cf = new CompoundFile(fileName);
-            DateTime dt = DateTime.Now;
+            var stopwatch = Stopwatch.StartNew();
             CFStream s = cf.RootStorage.GetStream("Test1");
-            TimeSpan ts = DateTime.Now.Subtract(dt);
-            Console.WriteLine(ts.TotalMilliseconds.ToString());
+            Console.WriteLine($"Elapsed: {stopwatch.Elapsed}");
             Console.Read();
         }
 


### PR DESCRIPTION
Fixes #161 by returning DateTimes as UTC

Also uses a monotonic clock for performance measurements.