### PR TITLE
2.4 API additions

### DIFF
--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -2489,8 +2489,7 @@ namespace OpenMcdf
 
         #region IDisposable Members
 
-
-        void IDisposable.Dispose()
+        public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -1507,26 +1507,6 @@ namespace OpenMcdf
 
         public CFSVersion Version => (CFSVersion)header.MajorVersion;
 
-        /// <summary>
-        /// Reset a directory entry setting it to StgInvalid in the Directory.
-        /// </summary>
-        /// <param name="sid">Sid of the directory to invalidate</param>
-        internal void ResetDirectoryEntry(int sid)
-        {
-            directoryEntries[sid].SetEntryName(string.Empty);
-            directoryEntries[sid].Left = null;
-            directoryEntries[sid].Right = null;
-            directoryEntries[sid].Parent = null;
-            directoryEntries[sid].StgType = StgType.StgInvalid;
-            directoryEntries[sid].StartSetc = DirectoryEntry.ZERO;
-            directoryEntries[sid].StorageCLSID = Guid.Empty;
-            directoryEntries[sid].Size = 0;
-            directoryEntries[sid].StateBits = 0;
-            directoryEntries[sid].StgColor = StgColor.Red;
-            directoryEntries[sid].CreationDate = new byte[8];
-            directoryEntries[sid].ModifyDate = new byte[8];
-        }
-
         //internal class NodeFactory : IRBTreeDeserializer<CFItem>
         //{
 
@@ -2416,13 +2396,6 @@ namespace OpenMcdf
             return i > 0 ? i : 0;
         }
 
-        internal void InvalidateDirectoryEntry(int sid)
-        {
-            if (sid >= directoryEntries.Count)
-                throw new CFException("Invalid SID of the directory entry to remove");
-
-            ResetDirectoryEntry(sid);
-        }
 
         internal void FreeAssociatedData(int sid)
         {

--- a/sources/OpenMcdf/DirectoryEntry.cs
+++ b/sources/OpenMcdf/DirectoryEntry.cs
@@ -455,5 +455,26 @@ namespace OpenMcdf
             d.storageCLSID = new Guid(storageCLSID.ToByteArray());
             d.Child = Child;
         }
+
+        /// <summary>
+        /// Reset a directory entry setting it to StgInvalid in the Directory.
+        /// </summary>
+        public void Reset()
+        {
+            // TODO: Delete IDirectoryEntry interface and use as DirectoryEntry
+            // member instead for improved performance from devirtualization
+            SetEntryName(string.Empty);
+            Left = null;
+            Right = null;
+            Parent = null;
+            StgType = StgType.StgInvalid;
+            StartSetc = ZERO;
+            StorageCLSID = Guid.Empty;
+            Size = 0;
+            StateBits = 0;
+            StgColor = StgColor.Red;
+            Array.Clear(CreationDate, 0, CreationDate.Length);
+            Array.Clear(ModifyDate, 0, ModifyDate.Length);
+        }
     }
 }

--- a/sources/OpenMcdf/IDirectoryEntry.cs
+++ b/sources/OpenMcdf/IDirectoryEntry.cs
@@ -32,5 +32,6 @@ namespace OpenMcdf
         StgType StgType { get; set; }
         Guid StorageCLSID { get; set; }
         void Write(System.IO.Stream stream);
+        void Reset();
     }
 }

--- a/sources/OpenMcdf/RBTree/RBTree.cs
+++ b/sources/OpenMcdf/RBTree/RBTree.cs
@@ -1,6 +1,7 @@
 ﻿#define ASSERT
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -88,7 +89,7 @@ namespace RedBlackTree
         void AssignValueTo(IRBNode other);
     }
 
-    public class RBTree
+    public class RBTree : IEnumerable<IRBNode>
     {
         public IRBNode Root { get; set; }
 
@@ -513,25 +514,25 @@ namespace RedBlackTree
         public class RBTreeEnumerator : IEnumerator<IRBNode>
         {
             int position = -1;
-            private readonly Queue<IRBNode> heap = new Queue<IRBNode>();
+            private readonly List<IRBNode> list = new();
 
             internal RBTreeEnumerator(RBTree tree)
             {
-                tree.VisitTreeNodes(item => heap.Enqueue(item));
+                tree.VisitTreeNodes(item => list.Add(item));
             }
-
-            public IRBNode Current => heap.ElementAt(position);
 
             public void Dispose()
             {
             }
 
-            object System.Collections.IEnumerator.Current => heap.ElementAt(position);
+            public IRBNode Current => list[position];
+
+            object IEnumerator.Current => list[position];
 
             public bool MoveNext()
             {
                 position++;
-                return position < heap.Count;
+                return position < list.Count;
             }
 
             public void Reset()
@@ -540,10 +541,9 @@ namespace RedBlackTree
             }
         }
 
-        public RBTreeEnumerator GetEnumerator()
-        {
-            return new RBTreeEnumerator(this);
-        }
+        public IEnumerator<IRBNode> GetEnumerator() => new RBTreeEnumerator(this);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         private const int INDENT_STEP = 15;
 


### PR DESCRIPTION
Adds the following methods:

- CompoundFile.Dispose (as public)
- ContainsStream
- ContainsStorage
- TryDelete

While adding them, I found some problems with the existing implementation that I have fixed since it made sense to do so at the same time:
- RBTreeEnumerator performed multiple enumeration on a Queue via LINQ, but RBTree did not support LINQ (IEnumerable<T>)
- Directory resets invloved multiple redundant casts and lookups