### PR TITLE
Fix object disposal in tests

### DIFF
--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -166,91 +166,75 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_SUMMARY_INFO_READ_UTF8_ISSUE_33()
         {
-            try
+            using (CompoundFile cf = new CompoundFile("wstr_presets.doc"))
             {
-                using (CompoundFile cf = new CompoundFile("wstr_presets.doc"))
+                var co = cf.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
+
+                foreach (OLEProperty p in co.Properties)
                 {
-                    var co = cf.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
-
-                    foreach (OLEProperty p in co.Properties)
-                    {
-                        Debug.Write(p.PropertyName);
-                        Debug.Write(" - ");
-                        Debug.Write(p.VTType);
-                        Debug.Write(" - ");
-                        Debug.WriteLine(p.Value);
-                    }
-
-                    Assert.IsNotNull(co.Properties);
-
-                    var co2 = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
-
-                    foreach (OLEProperty p in co2.Properties)
-                    {
-                        Debug.Write(p.PropertyName);
-                        Debug.Write(" - ");
-                        Debug.Write(p.VTType);
-                        Debug.Write(" - ");
-                        Debug.WriteLine(p.Value);
-                    }
-
-                    Assert.IsNotNull(co2.Properties);
+                    Debug.Write(p.PropertyName);
+                    Debug.Write(" - ");
+                    Debug.Write(p.VTType);
+                    Debug.Write(" - ");
+                    Debug.WriteLine(p.Value);
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                Assert.Fail();
+
+                Assert.IsNotNull(co.Properties);
+
+                var co2 = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
+
+                foreach (OLEProperty p in co2.Properties)
+                {
+                    Debug.Write(p.PropertyName);
+                    Debug.Write(" - ");
+                    Debug.Write(p.VTType);
+                    Debug.Write(" - ");
+                    Debug.WriteLine(p.Value);
+                }
+
+                Assert.IsNotNull(co2.Properties);
             }
         }
 
         [TestMethod]
         public void Test_SUMMARY_INFO_READ_UTF8_ISSUE_34()
         {
-            try
+            using (CompoundFile cf = new CompoundFile("2custom.doc"))
             {
-                using (CompoundFile cf = new CompoundFile("2custom.doc"))
+                var co = cf.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
+
+                foreach (OLEProperty p in co.Properties)
                 {
-                    var co = cf.RootStorage.GetStream("\u0005SummaryInformation").AsOLEPropertiesContainer();
-
-                    foreach (OLEProperty p in co.Properties)
-                    {
-                        Debug.Write(p.PropertyName);
-                        Debug.Write(" - ");
-                        Debug.Write(p.VTType);
-                        Debug.Write(" - ");
-                        Debug.WriteLine(p.Value);
-                    }
-
-                    Assert.IsNotNull(co.Properties);
-
-                    var co2 = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
-
-                    Assert.IsNotNull(co2.Properties);
-                    foreach (OLEProperty p in co2.Properties)
-                    {
-                        Debug.Write(p.PropertyName);
-                        Debug.Write(" - ");
-                        Debug.Write(p.VTType);
-                        Debug.Write(" - ");
-                        Debug.WriteLine(p.Value);
-                    }
-
-                    Assert.IsNotNull(co2.UserDefinedProperties.Properties);
-                    foreach (OLEProperty p in co2.UserDefinedProperties.Properties)
-                    {
-                        Debug.Write(p.PropertyName);
-                        Debug.Write(" - ");
-                        Debug.Write(p.VTType);
-                        Debug.Write(" - ");
-                        Debug.WriteLine(p.Value);
-                    }
+                    Debug.Write(p.PropertyName);
+                    Debug.Write(" - ");
+                    Debug.Write(p.VTType);
+                    Debug.Write(" - ");
+                    Debug.WriteLine(p.Value);
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                Assert.Fail();
+
+                Assert.IsNotNull(co.Properties);
+
+                var co2 = cf.RootStorage.GetStream("\u0005DocumentSummaryInformation").AsOLEPropertiesContainer();
+
+                Assert.IsNotNull(co2.Properties);
+                foreach (OLEProperty p in co2.Properties)
+                {
+                    Debug.Write(p.PropertyName);
+                    Debug.Write(" - ");
+                    Debug.Write(p.VTType);
+                    Debug.Write(" - ");
+                    Debug.WriteLine(p.Value);
+                }
+
+                Assert.IsNotNull(co2.UserDefinedProperties.Properties);
+                foreach (OLEProperty p in co2.UserDefinedProperties.Properties)
+                {
+                    Debug.Write(p.PropertyName);
+                    Debug.Write(" - ");
+                    Debug.Write(p.VTType);
+                    Debug.Write(" - ");
+                    Debug.WriteLine(p.Value);
+                }
             }
         }
 

--- a/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
+++ b/sources/Test/OpenMcdf.Extensions.Test/OLEPropertiesExtensionsTest.cs
@@ -93,8 +93,7 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_DOCUMENT_SUMMARY_INFO_ROUND_TRIP()
         {
-            if (File.Exists("test1.cfs"))
-                File.Delete("test1.cfs");
+            File.Delete("test1.cfs");
 
             using (CompoundFile cf = new CompoundFile("_Test.ppt"))
             {
@@ -117,8 +116,7 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_DOCUMENT_SUMMARY_INFO_MODIFY()
         {
-            if (File.Exists("test_modify_summary.ppt"))
-                File.Delete("test_modify_summary.ppt");
+            File.Delete("test_modify_summary.ppt");
 
             // Verify initial properties, and then create a modified document
             using (CompoundFile cf = new CompoundFile("_Test.ppt"))
@@ -264,8 +262,7 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_SUMMARY_INFO_MODIFY_LPWSTRING()
         {
-            if (File.Exists("test_write_lpwstr.doc"))
-                File.Delete("test_write_lpwstr.doc");
+            File.Delete("test_write_lpwstr.doc");
 
             // Modify some LPWSTR properties, and save to a new file
             using (CompoundFile cf = new CompoundFile("wstr_presets.doc"))
@@ -345,8 +342,7 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_DOCUMENT_SUMMARY_INFO_ADD_CUSTOM()
         {
-            if (File.Exists("test_add_user_defined_property.doc"))
-                File.Delete("test_add_user_defined_property.doc");
+            File.Delete("test_add_user_defined_property.doc");
 
             // Test value for a VT_FILETIME property
             DateTime testNow = DateTime.UtcNow;
@@ -456,8 +452,7 @@ namespace OpenMcdf.Extensions.Test
         [TestMethod]
         public void Test_ADD_USER_DEFINED_PROPERTIES_SECTION()
         {
-            if (File.Exists("test_add_user_defined_properties.xls"))
-                File.Delete("test_add_user_defined_properties.xls");
+            File.Delete("test_add_user_defined_properties.xls");
 
             using (CompoundFile cf = new CompoundFile("report.xls"))
             {

--- a/sources/Test/OpenMcdf.Test/CFStorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStorageTest.cs
@@ -160,8 +160,7 @@ namespace OpenMcdf.Test
             string FILENAME = "testVisiting.xls";
 
             // Remove...
-            if (File.Exists(FILENAME))
-                File.Delete(FILENAME);
+            File.Delete(FILENAME);
 
             //Create...
 
@@ -290,15 +289,8 @@ namespace OpenMcdf.Test
             cf.SaveAs("$Hel2");
             cf.Close();
 
-            if (File.Exists("$Hel1"))
-            {
-                File.Delete("$Hel1");
-            }
-
-            if (File.Exists("$Hel2"))
-            {
-                File.Delete("$Hel2");
-            }
+            File.Delete("$Hel1");
+            File.Delete("$Hel2");
         }
 
         [TestMethod]

--- a/sources/Test/OpenMcdf.Test/CFStorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStorageTest.cs
@@ -341,10 +341,8 @@ namespace OpenMcdf.Test
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CORRUPTEDDOC_BUG36_SHOULD_THROW_CORRUPTED_FILE_EXCEPTION()
         {
-            using (CompoundFile file = new CompoundFile("CorruptedDoc_bug36.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException))
-            {
-                //Many thanks to theseus for bug reporting
-            }
+            using CompoundFile file = new CompoundFile("CorruptedDoc_bug36.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException);
+            //Many thanks to theseus for bug reporting
         }
     }
 }

--- a/sources/Test/OpenMcdf.Test/CFStorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStorageTest.cs
@@ -50,7 +50,7 @@ namespace OpenMcdf.Test
         public void Test_CREATE_STORAGE()
         {
             const string STORAGE_NAME = "NewStorage";
-            CompoundFile cf = new CompoundFile();
+            using CompoundFile cf = new();
 
             CFStorage st = cf.RootStorage.AddStorage(STORAGE_NAME);
 
@@ -62,7 +62,7 @@ namespace OpenMcdf.Test
         public void Test_CREATE_STORAGE_WITH_CREATION_DATE()
         {
             const string STORAGE_NAME = "NewStorage1";
-            CompoundFile cf = new CompoundFile();
+            using CompoundFile cf = new();
 
             CFStorage st = cf.RootStorage.AddStorage(STORAGE_NAME);
             st.CreationDate = DateTime.Now;
@@ -71,17 +71,16 @@ namespace OpenMcdf.Test
             Assert.AreEqual(STORAGE_NAME, st.Name, false);
 
             cf.SaveAs("ProvaData.cfs");
-            cf.Close();
         }
 
         [TestMethod]
         public void Test_VISIT_ENTRIES()
         {
             const string STORAGE_NAME = "report.xls";
-            CompoundFile cf = new CompoundFile(STORAGE_NAME);
+            using CompoundFile cf = new(STORAGE_NAME);
 
-            FileStream output = new FileStream("LogEntries.txt", FileMode.Create);
-            StreamWriter tw = new StreamWriter(output);
+            using FileStream output = new("LogEntries.txt", FileMode.Create);
+            using StreamWriter tw = new(output);
 
             Action<CFItem> va = delegate (CFItem item)
             {
@@ -89,15 +88,13 @@ namespace OpenMcdf.Test
             };
 
             cf.RootStorage.VisitEntries(va, true);
-
-            tw.Close();
         }
 
         [TestMethod]
         public void Test_TRY_GET_STREAM_STORAGE()
         {
             string FILENAME = "MultipleStorage.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using CompoundFile cf = new(FILENAME);
 
             cf.RootStorage.TryGetStorage("MyStorage", out CFStorage st);
             Assert.IsNotNull(st);
@@ -116,7 +113,7 @@ namespace OpenMcdf.Test
         public void Test_TRY_GET_STREAM_STORAGE_NEW()
         {
             string FILENAME = "MultipleStorage.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using CompoundFile cf = new(FILENAME);
             bool bs = cf.RootStorage.TryGetStorage("MyStorage", out CFStorage st);
 
             Assert.IsTrue(bs);
@@ -135,7 +132,7 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_VISIT_ENTRIES_CORRUPTED_FILE_VALIDATION_ON()
         {
-            CompoundFile f = new CompoundFile("CorruptedDoc_bug3547815.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
+            using CompoundFile f = new("CorruptedDoc_bug3547815.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
 
             Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
@@ -147,11 +144,10 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_VISIT_ENTRIES_CORRUPTED_FILE_VALIDATION_OFF_BUT_CAN_LOAD()
         {
-            CompoundFile f = new CompoundFile("CorruptedDoc_bug3547815_B.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException);
+            using CompoundFile f = new("CorruptedDoc_bug3547815_B.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException);
 
-            using StreamWriter tw = new StreamWriter("LogEntriesCorrupted_2.txt");
+            using StreamWriter tw = new("LogEntriesCorrupted_2.txt");
             f.RootStorage.VisitEntries(item => tw.WriteLine(item.Name), true);
-            tw.Flush();
         }
 
         [TestMethod]
@@ -164,26 +160,25 @@ namespace OpenMcdf.Test
 
             //Create...
 
-            CompoundFile ncf = new CompoundFile();
+            using (CompoundFile ncf = new())
+            {
+                CFStorage l1 = ncf.RootStorage.AddStorage("Storage Level 1");
+                l1.AddStream("l1ns1");
+                l1.AddStream("l1ns2");
+                l1.AddStream("l1ns3");
 
-            CFStorage l1 = ncf.RootStorage.AddStorage("Storage Level 1");
-            l1.AddStream("l1ns1");
-            l1.AddStream("l1ns2");
-            l1.AddStream("l1ns3");
+                CFStorage l2 = l1.AddStorage("Storage Level 2");
+                l2.AddStream("l2ns1");
+                l2.AddStream("l2ns2");
 
-            CFStorage l2 = l1.AddStorage("Storage Level 2");
-            l2.AddStream("l2ns1");
-            l2.AddStream("l2ns2");
-
-            ncf.SaveAs(FILENAME);
-            ncf.Close();
+                ncf.SaveAs(FILENAME);
+            }
 
             // Read...
 
-            CompoundFile cf = new CompoundFile(FILENAME);
-
-            FileStream output = new FileStream("reportVisit.txt", FileMode.Create);
-            StreamWriter sw = new StreamWriter(output);
+            using CompoundFile cf = new(FILENAME);
+            using FileStream output = new("reportVisit.txt", FileMode.Create);
+            using StreamWriter sw = new(output);
 
             Console.SetOut(sw);
 
@@ -193,16 +188,13 @@ namespace OpenMcdf.Test
             };
 
             cf.RootStorage.VisitEntries(va, true);
-
-            cf.Close();
-            sw.Close();
         }
 
         [TestMethod]
         public void Test_DELETE_DIRECTORY()
         {
             string FILENAME = "MultipleStorage2.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME, CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
+            using CompoundFile cf = new(FILENAME, CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
 
             CFStorage st = cf.RootStorage.GetStorage("MyStorage");
 
@@ -211,15 +203,13 @@ namespace OpenMcdf.Test
             st.Delete("AnotherStorage");
 
             cf.SaveAs("MultipleStorage_Delete.cfs");
-
-            cf.Close();
         }
 
         [TestMethod]
         public void Test_DELETE_MINISTREAM_STREAM()
         {
             string FILENAME = "MultipleStorage2.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using CompoundFile cf = new(FILENAME);
 
             CFStorage found = null;
             Action<CFItem> action = delegate (CFItem item) { if (item.Name == "AnotherStorage") found = item as CFStorage; };
@@ -230,14 +220,13 @@ namespace OpenMcdf.Test
             found.Delete("AnotherStream");
 
             cf.SaveAs("MultipleDeleteMiniStream");
-            cf.Close();
         }
 
         [TestMethod]
         public void Test_DELETE_STREAM()
         {
             string FILENAME = "MultipleStorage3.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using CompoundFile cf = new(FILENAME);
 
             CFStorage found = null;
             Action<CFItem> action = delegate (CFItem item)
@@ -253,14 +242,13 @@ namespace OpenMcdf.Test
             found.Delete("Another2Stream");
 
             cf.SaveAs("MultipleDeleteStream");
-            cf.Close();
         }
 
         [TestMethod]
         public void Test_CHECK_DISPOSED_()
         {
             const string FILENAME = "MultipleStorage.cfs";
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using CompoundFile cf = new CompoundFile(FILENAME);
 
             CFStorage st = cf.RootStorage.GetStorage("MyStorage");
             cf.Close();
@@ -271,23 +259,23 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_LAZY_LOAD_CHILDREN_()
         {
-            CompoundFile cf = new CompoundFile();
-            cf.RootStorage.AddStorage("Level_1")
-                .AddStorage("Level_2")
-                .AddStream("Level2Stream")
-                .SetData(Helpers.GetBuffer(100));
+            using (CompoundFile cf = new())
+            {
+                cf.RootStorage.AddStorage("Level_1")
+                    .AddStorage("Level_2")
+                    .AddStream("Level2Stream")
+                    .SetData(Helpers.GetBuffer(100));
+                cf.SaveAs("$Hel1");
+            }
 
-            cf.SaveAs("$Hel1");
-
-            cf.Close();
-
-            cf = new CompoundFile("$Hel1");
-            IList<CFItem> i = cf.GetAllNamedEntries("Level2Stream");
-            Assert.IsNotNull(i[0]);
-            Assert.IsTrue(i[0] is CFStream);
-            Assert.AreEqual(100, (i[0] as CFStream).GetData().Length);
-            cf.SaveAs("$Hel2");
-            cf.Close();
+            using (CompoundFile cf = new("$Hel1"))
+            {
+                IList<CFItem> i = cf.GetAllNamedEntries("Level2Stream");
+                Assert.IsNotNull(i[0]);
+                Assert.IsTrue(i[0] is CFStream);
+                Assert.AreEqual(100, (i[0] as CFStream).GetData().Length);
+                cf.SaveAs("$Hel2");
+            }
 
             File.Delete("$Hel1");
             File.Delete("$Hel2");
@@ -296,17 +284,16 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_FIX_BUG_31()
         {
-            CompoundFile cf = new CompoundFile();
-            cf.RootStorage.AddStorage("Level_1")
+            using (CompoundFile cf = new())
+            {
+                cf.RootStorage.AddStorage("Level_1")
+                    .AddStream("Level2Stream")
+                    .SetData(Helpers.GetBuffer(100));
 
-                .AddStream("Level2Stream")
-                .SetData(Helpers.GetBuffer(100));
+                cf.SaveAs("$Hel3");
+            }
 
-            cf.SaveAs("$Hel3");
-
-            cf.Close();
-
-            CompoundFile cf1 = new CompoundFile("$Hel3");
+            using CompoundFile cf1 = new("$Hel3");
 
             Assert.ThrowsException<CFDuplicatedItemException>(() =>
             {
@@ -317,22 +304,22 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_FIX_BUG_116()
         {
-            CompoundFile cf = new CompoundFile();
-            cf.RootStorage.AddStorage("AStorage")
-                .AddStream("AStream")
-                .SetData(Helpers.GetBuffer(100));
+            using (CompoundFile cf = new())
+            {
+                cf.RootStorage.AddStorage("AStorage")
+                    .AddStream("AStream")
+                    .SetData(Helpers.GetBuffer(100));
 
-            cf.SaveAs("Hello$File");
+                cf.SaveAs("Hello$File");
+            }
 
-            cf.Close();
+            using (CompoundFile cf1 = new("Hello$File", CFSUpdateMode.Update, CFSConfiguration.Default))
+            {
+                cf1.RootStorage.RenameItem("AStorage", "NewStorage");
+                cf1.Commit();
+            }
 
-            CompoundFile cf1 = new CompoundFile("Hello$File", CFSUpdateMode.Update, CFSConfiguration.Default);
-
-            cf1.RootStorage.RenameItem("AStorage", "NewStorage");
-            cf1.Commit();
-            cf1.Close();
-
-            CompoundFile cf2 = new CompoundFile("Hello$File");
+            using CompoundFile cf2 = new CompoundFile("Hello$File");
             var st2 = cf2.RootStorage.GetStorage("NewStorage");
             Assert.IsNotNull(st2);
         }

--- a/sources/Test/OpenMcdf.Test/CFStorageTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStorageTest.cs
@@ -102,27 +102,14 @@ namespace OpenMcdf.Test
             cf.RootStorage.TryGetStorage("MyStorage", out CFStorage st);
             Assert.IsNotNull(st);
 
-            try
-            {
-                cf.RootStorage.TryGetStorage("IDONTEXIST", out CFStorage nf);
-                Assert.IsNull(nf);
-            }
-            catch (Exception)
-            {
-                Assert.Fail("Exception raised for try_get method");
-            }
+            cf.RootStorage.TryGetStorage("IDONTEXIST", out CFStorage nf);
+            Assert.IsNull(nf);
 
-            try
-            {
-                st.TryGetStream("MyStream", out CFStream s);
-                Assert.IsNotNull(s);
-                st.TryGetStream("IDONTEXIST2", out CFStream ns);
-                Assert.IsNull(ns);
-            }
-            catch (Exception)
-            {
-                Assert.Fail("Exception raised for try_get method");
-            }
+            st.TryGetStream("MyStream", out CFStream s);
+            Assert.IsNotNull(s);
+            st.TryGetStream("IDONTEXIST2", out CFStream ns);
+            Assert.IsNull(ns);
+
         }
 
         [TestMethod]
@@ -135,44 +122,20 @@ namespace OpenMcdf.Test
             Assert.IsTrue(bs);
             Assert.IsNotNull(st);
 
-            try
-            {
-                bool nb = cf.RootStorage.TryGetStorage("IDONTEXIST", out CFStorage nf);
-                Assert.IsFalse(nb);
-                Assert.IsNull(nf);
-            }
-            catch (Exception)
-            {
-                Assert.Fail("Exception raised for TryGetStorage method");
-            }
+            bool nb = cf.RootStorage.TryGetStorage("IDONTEXIST", out CFStorage nf);
+            Assert.IsFalse(nb);
+            Assert.IsNull(nf);
 
-            try
-            {
-                var b = st.TryGetStream("MyStream", out CFStream s);
-                Assert.IsNotNull(s);
-                b = st.TryGetStream("IDONTEXIST2", out CFStream ns);
-                Assert.IsFalse(b);
-            }
-            catch (Exception)
-            {
-                Assert.Fail("Exception raised for try_get method");
-            }
+            var b = st.TryGetStream("MyStream", out CFStream s);
+            Assert.IsNotNull(s);
+            b = st.TryGetStream("IDONTEXIST2", out CFStream ns);
+            Assert.IsFalse(b);
         }
 
         [TestMethod]
         public void Test_VISIT_ENTRIES_CORRUPTED_FILE_VALIDATION_ON()
         {
-            CompoundFile f;
-
-            try
-            {
-                f = new CompoundFile("CorruptedDoc_bug3547815.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
-            }
-            catch
-            {
-                Assert.Fail("No exception has to be fired on creation due to lazy loading");
-                return;
-            }
+            CompoundFile f = new CompoundFile("CorruptedDoc_bug3547815.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
 
             Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
@@ -184,28 +147,11 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_VISIT_ENTRIES_CORRUPTED_FILE_VALIDATION_OFF_BUT_CAN_LOAD()
         {
-            CompoundFile f = null;
+            CompoundFile f = new CompoundFile("CorruptedDoc_bug3547815_B.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException);
 
-            try
-            {
-                // Corrupted file has invalid children item sid reference
-                f = new CompoundFile("CorruptedDoc_bug3547815_B.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.NoValidationException);
-            }
-            catch
-            {
-                Assert.Fail("No exception has to be fired on creation due to lazy loading");
-            }
-
-            try
-            {
-                using StreamWriter tw = new StreamWriter("LogEntriesCorrupted_2.txt");
-                f.RootStorage.VisitEntries(item => tw.WriteLine(item.Name), true);
-                tw.Flush();
-            }
-            catch
-            {
-                Assert.Fail("Fail is corrupted but it has to be loaded anyway by test design");
-            }
+            using StreamWriter tw = new StreamWriter("LogEntriesCorrupted_2.txt");
+            f.RootStorage.VisitEntries(item => tw.WriteLine(item.Name), true);
+            tw.Flush();
         }
 
         [TestMethod]
@@ -381,7 +327,6 @@ namespace OpenMcdf.Test
         {
             CompoundFile cf = new CompoundFile();
             cf.RootStorage.AddStorage("AStorage")
-
                 .AddStream("AStream")
                 .SetData(Helpers.GetBuffer(100));
 
@@ -391,27 +336,13 @@ namespace OpenMcdf.Test
 
             CompoundFile cf1 = new CompoundFile("Hello$File", CFSUpdateMode.Update, CFSConfiguration.Default);
 
-            try
-            {
-                cf1.RootStorage.RenameItem("AStorage", "NewStorage");
-                cf1.Commit();
-                cf1.Close();
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.Message);
-            }
+            cf1.RootStorage.RenameItem("AStorage", "NewStorage");
+            cf1.Commit();
+            cf1.Close();
 
-            try
-            {
-                CompoundFile cf2 = new CompoundFile("Hello$File");
-                var st2 = cf2.RootStorage.GetStorage("NewStorage");
-                Assert.IsNotNull(st2);
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail($"{ex.Message}");
-            }
+            CompoundFile cf2 = new CompoundFile("Hello$File");
+            var st2 = cf2.RootStorage.GetStorage("NewStorage");
+            Assert.IsNotNull(st2);
         }
 
         [TestMethod]

--- a/sources/Test/OpenMcdf.Test/CFStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStreamTest.cs
@@ -118,10 +118,6 @@ namespace OpenMcdf.Test
                 myStream.SetData(b);
                 cf.SaveAs("ZERO_LENGTH_STREAM.cfs");
             }
-            catch
-            {
-                Assert.Fail("Failed setting zero length stream");
-            }
             finally
             {
                 if (cf != null)
@@ -142,14 +138,7 @@ namespace OpenMcdf.Test
 
             Assert.IsNotNull(myStream);
 
-            try
-            {
-                myStream.SetData(b);
-            }
-            catch
-            {
-                Assert.Fail("Failed setting zero length stream");
-            }
+            myStream.SetData(b);
 
             cf.SaveAs("ZERO_LENGTH_STREAM_RE.cfs");
             cf.Close();
@@ -164,10 +153,6 @@ namespace OpenMcdf.Test
             {
                 oStream.SetData(Helpers.GetBuffer(30));
                 cfo.SaveAs("ZERO_LENGTH_STREAM_RE2.cfs");
-            }
-            catch
-            {
-                Assert.Fail("Failed re-writing zero length stream");
             }
             finally
             {
@@ -551,14 +536,7 @@ namespace OpenMcdf.Test
 
             Assert.IsNotNull(myStream);
 
-            try
-            {
-                myStream.SetData(b);
-            }
-            catch
-            {
-                Assert.Fail("Failed setting zero length stream");
-            }
+            myStream.SetData(b);
 
             string filename = "DeleteZeroLengthStream.cfs";
             cf.SaveAs(filename);
@@ -1024,33 +1002,26 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_CHANGE_STREAM_NAME_FIX_54()
         {
-            try
-            {
-                CompoundFile cf = new CompoundFile("report.xls", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
-                cf.RootStorage.RenameItem("Workbook", "Workbuk");
+            CompoundFile cf = new CompoundFile("report.xls", CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
+            cf.RootStorage.RenameItem("Workbook", "Workbuk");
 
-                cf.SaveAs("report_n.xls");
-                cf.Close();
+            cf.SaveAs("report_n.xls");
+            cf.Close();
 
-                CompoundFile cf2 = new CompoundFile("report_n.xls", CFSUpdateMode.Update, CFSConfiguration.Default);
-                cf2.RootStorage.RenameItem("Workbuk", "Workbook");
-                cf2.Commit();
-                cf2.Close();
+            CompoundFile cf2 = new CompoundFile("report_n.xls", CFSUpdateMode.Update, CFSConfiguration.Default);
+            cf2.RootStorage.RenameItem("Workbuk", "Workbook");
+            cf2.Commit();
+            cf2.Close();
 
-                CompoundFile cf3 = new CompoundFile("MultipleStorage.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
-                cf3.RootStorage.RenameItem("MyStorage", "MyNewStorage");
-                cf3.Commit();
-                cf3.Close();
+            CompoundFile cf3 = new CompoundFile("MultipleStorage.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
+            cf3.RootStorage.RenameItem("MyStorage", "MyNewStorage");
+            cf3.Commit();
+            cf3.Close();
 
-                CompoundFile cf4 = new CompoundFile("MultipleStorage.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
-                cf4.RootStorage.RenameItem("MyNewStorage", "MyStorage");
-                cf4.Commit();
-                cf4.Close();
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail("Unexpected exception raised: " + ex.Message);
-            }
+            CompoundFile cf4 = new CompoundFile("MultipleStorage.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
+            cf4.RootStorage.RenameItem("MyNewStorage", "MyStorage");
+            cf4.Commit();
+            cf4.Close();
         }
 
         /// <summary>

--- a/sources/Test/OpenMcdf.Test/CFStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStreamTest.cs
@@ -571,15 +571,7 @@ namespace OpenMcdf.Test
 
             CFStream zeroStream2 = null;
 
-            try
-            {
-                zeroStream2 = cf2.RootStorage.GetStream(zeroLengthName);
-            }
-            catch (Exception ex)
-            {
-                Assert.IsNull(zeroStream2);
-                Assert.IsInstanceOfType(ex, typeof(CFItemNotFound));
-            }
+            Assert.ThrowsException<CFItemNotFound>(() => zeroStream2 = cf2.RootStorage.GetStream(zeroLengthName));
 
             cf2.SaveAs("MultipleDeleteMiniStream.cfs");
             cf2.Close();

--- a/sources/Test/OpenMcdf.Test/CFStreamTest.cs
+++ b/sources/Test/OpenMcdf.Test/CFStreamTest.cs
@@ -124,8 +124,7 @@ namespace OpenMcdf.Test
                     cf.Close();
             }
 
-            if (File.Exists("ZERO_LENGTH_STREAM.cfs"))
-                File.Delete("ZERO_LENGTH_STREAM.cfs");
+            File.Delete("ZERO_LENGTH_STREAM.cfs");
         }
 
         [TestMethod]
@@ -159,11 +158,9 @@ namespace OpenMcdf.Test
                 cfo.Close();
             }
 
-            if (File.Exists("ZERO_LENGTH_STREAM_RE.cfs"))
-                File.Delete("ZERO_LENGTH_STREAM_RE.cfs");
+            File.Delete("ZERO_LENGTH_STREAM_RE.cfs");
 
-            if (File.Exists("ZERO_LENGTH_STREAM_RE2.cfs"))
-                File.Delete("ZERO_LENGTH_STREAM_RE2.cfs");
+            File.Delete("ZERO_LENGTH_STREAM_RE2.cfs");
         }
 
         [TestMethod]
@@ -191,8 +188,7 @@ namespace OpenMcdf.Test
 
             cf2.Close();
 
-            if (File.Exists("WRITE_STREAM_WITH_DIFAT.cfs"))
-                File.Delete("WRITE_STREAM_WITH_DIFAT.cfs");
+            File.Delete("WRITE_STREAM_WITH_DIFAT.cfs");
         }
 
         [TestMethod]
@@ -268,11 +264,9 @@ namespace OpenMcdf.Test
 
             cfc.Close();
 
-            if (File.Exists("WRITE_MINISTREAM_READ_REWRITE_STREAM.cfs"))
-                File.Delete("WRITE_MINISTREAM_READ_REWRITE_STREAM.cfs");
+            File.Delete("WRITE_MINISTREAM_READ_REWRITE_STREAM.cfs");
 
-            if (File.Exists("WRITE_MINISTREAM_READ_REWRITE_STREAM_2ND.cfs"))
-                File.Delete("WRITE_MINISTREAM_READ_REWRITE_STREAM_2ND.cfs");
+            File.Delete("WRITE_MINISTREAM_READ_REWRITE_STREAM_2ND.cfs");
         }
 
         [TestMethod]
@@ -295,8 +289,7 @@ namespace OpenMcdf.Test
             Assert.AreEqual(BUFFER_LENGTH, c.Length);
             cf.Close();
 
-            if (File.Exists("reportRW_SMALL.xls"))
-                File.Delete("reportRW_SMALL.xls");
+            File.Delete("reportRW_SMALL.xls");
         }
 
         [TestMethod]
@@ -318,8 +311,7 @@ namespace OpenMcdf.Test
             CollectionAssert.AreEqual(c, b);
             cf.Close();
 
-            if (File.Exists("RE_WRITE_SMALLER_MINI_STREAM.xls"))
-                File.Delete("RE_WRITE_SMALLER_MINI_STREAM.xls");
+            File.Delete("RE_WRITE_SMALLER_MINI_STREAM.xls");
         }
 
         [TestMethod]
@@ -340,8 +332,7 @@ namespace OpenMcdf.Test
             cf.Commit();
             cf.Close();
 
-            if (File.Exists("reportOverwrite.xls"))
-                File.Delete("reportOverwrite.xls");
+            File.Delete("reportOverwrite.xls");
         }
 
         [TestMethod]
@@ -385,11 +376,9 @@ namespace OpenMcdf.Test
             cf.SaveAs(dstFilename + "PP");
             cf.Close();
 
-            if (File.Exists("reportOverwriteMultiple.xls"))
-                File.Delete("reportOverwriteMultiple.xls");
+            File.Delete("reportOverwriteMultiple.xls");
 
-            if (File.Exists("reportOverwriteMultiple.xlsPP"))
-                File.Delete("reportOverwriteMultiple.xlsPP");
+            File.Delete("reportOverwriteMultiple.xlsPP");
         }
 
         [TestMethod]
@@ -419,8 +408,7 @@ namespace OpenMcdf.Test
             larger.Close();
             smaller.Close();
 
-            if (File.Exists("reportOverwriteMultiple.xlsPP"))
-                File.Delete("reportOverwriteMultiple.xlsPP");
+            File.Delete("reportOverwriteMultiple.xlsPP");
         }
 
         [TestMethod]
@@ -443,8 +431,7 @@ namespace OpenMcdf.Test
             cf.Commit();
             cf.Close();
 
-            if (File.Exists("reportOverwrite2.xlsPP"))
-                File.Delete("reportOverwrite2.xlsPP");
+            File.Delete("reportOverwrite2.xlsPP");
         }
 
         [TestMethod]
@@ -498,8 +485,7 @@ namespace OpenMcdf.Test
             Assert.IsNotNull(sm2);
             Assert.AreEqual(220, sm2.Size);
 
-            if (File.Exists(filename))
-                File.Delete(filename);
+            File.Delete(filename);
         }
 
         [TestMethod]
@@ -572,8 +558,7 @@ namespace OpenMcdf.Test
         {
             string filename = "INCREMENTAL_SIZE_MULTIPLE_WRITE_AND_READ_CFS.cfs";
 
-            if (File.Exists(filename))
-                File.Delete(filename);
+            File.Delete(filename);
 
             CompoundFile cf = new CompoundFile();
             CFStorage st = cf.RootStorage.AddStorage("MyStorage");
@@ -600,8 +585,7 @@ namespace OpenMcdf.Test
         {
             string filename = "INCREMENTAL_SIZE_MULTIPLE_WRITE_AND_READ_CFS.cfs";
 
-            if (File.Exists(filename))
-                File.Delete(filename);
+            File.Delete(filename);
 
             CompoundFile cf = new CompoundFile();
             CFStorage st = cf.RootStorage.AddStorage("MyStorage");
@@ -784,8 +768,7 @@ namespace OpenMcdf.Test
             CollectionAssert.AreEqual(b100, cf.RootStorage.GetStream("AStream").GetData());
             cf.Close();
 
-            if (File.Exists(FILE_NAME))
-                File.Delete(FILE_NAME);
+            File.Delete(FILE_NAME);
         }
 
         [TestMethod]

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -54,15 +54,15 @@ namespace OpenMcdf.Test
 
             File.Copy(FILENAME, "MultipleStorage_Deleted_Compress.cfs", true);
 
-            CompoundFile cf = new CompoundFile("MultipleStorage_Deleted_Compress.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
+            using (CompoundFile cf = new("MultipleStorage_Deleted_Compress.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors))
+            {
+                CFStorage st = cf.RootStorage.GetStorage("MyStorage");
+                st = st.GetStorage("AnotherStorage");
 
-            CFStorage st = cf.RootStorage.GetStorage("MyStorage");
-            st = st.GetStorage("AnotherStorage");
-
-            Assert.IsNotNull(st);
-            st.Delete("Another2Stream");
-            cf.Commit();
-            cf.Close();
+                Assert.IsNotNull(st);
+                st.Delete("Another2Stream");
+                cf.Commit();
+            }
 
             CompoundFile.ShrinkCompoundFile("MultipleStorage_Deleted_Compress.cfs"); // -> 7Kb
 
@@ -74,9 +74,9 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_ENTRY_NAME_LENGTH()
         {
-            //Thanks to Mark Bosold for bug fix and unit
+            // Thanks to Mark Bosold for bug fix and unit
 
-            CompoundFile cf = new CompoundFile();
+            using CompoundFile cf = new();
 
             // Cannot be equal.
             string maxCharactersStreamName = "1234567890123456789A12345678901"; // 31 chars
@@ -101,7 +101,6 @@ namespace OpenMcdf.Test
             Assert.ThrowsException<CFException>(() => cf.RootStorage.AddStream(tooManyCharactersEntryName));
 
             cf.SaveAs("EntryNameLength");
-            cf.Close();
         }
 
         [TestMethod]
@@ -111,19 +110,20 @@ namespace OpenMcdf.Test
 
             FileInfo srcFile = new FileInfo(FILENAME);
 
-            CompoundFile cf = new CompoundFile(FILENAME);
+            using (CompoundFile cf = new(FILENAME))
+            {
 
-            CFStorage st = cf.RootStorage.GetStorage("MyStorage");
-            st = st.GetStorage("AnotherStorage");
+                CFStorage st = cf.RootStorage.GetStorage("MyStorage");
+                st = st.GetStorage("AnotherStorage");
 
-            Assert.IsNotNull(st);
+                Assert.IsNotNull(st);
 
-            st.Delete("Another2Stream"); //17Kb
+                st.Delete("Another2Stream"); //17Kb
 
-            //cf.CompressFreeSpace();
-            cf.SaveAs("MultipleStorage_Deleted_Compress.cfs");
+                //cf.CompressFreeSpace();
+                cf.SaveAs("MultipleStorage_Deleted_Compress.cfs");
+            }
 
-            cf.Close();
             FileInfo dstFile = new FileInfo("MultipleStorage_Deleted_Compress.cfs");
 
             Assert.IsFalse(srcFile.Length > dstFile.Length);
@@ -134,49 +134,45 @@ namespace OpenMcdf.Test
         {
             string filename = "WRITE_AND_READ_CFS_V4.cfs";
 
-            CompoundFile cf = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.EraseFreeSectors | CFSConfiguration.SectorRecycle);
+            using (CompoundFile cf = new(CFSVersion.Ver_4, CFSConfiguration.EraseFreeSectors | CFSConfiguration.SectorRecycle))
+            {
+                CFStorage st = cf.RootStorage.AddStorage("MyStorage");
+                CFStream sm = st.AddStream("MyStream");
+                byte[] b = new byte[220];
+                sm.SetData(b);
 
-            CFStorage st = cf.RootStorage.AddStorage("MyStorage");
-            CFStream sm = st.AddStream("MyStream");
-            byte[] b = new byte[220];
-            sm.SetData(b);
+                cf.SaveAs(filename);
+            }
 
-            cf.SaveAs(filename);
-            cf.Close();
-
-            CompoundFile cf2 = new CompoundFile(filename);
+            using CompoundFile cf2 = new CompoundFile(filename);
             CFStorage st2 = cf2.RootStorage.GetStorage("MyStorage");
             CFStream sm2 = st2.GetStream("MyStream");
 
             Assert.IsNotNull(sm2);
             Assert.AreEqual(220, sm2.Size);
-
-            cf2.Close();
         }
 
         [TestMethod]
         public void Test_WRITE_READ_CFS_VERSION_4_STREAM()
         {
             string filename = "WRITE_COMMIT_READ_CFS_V4.cfs";
-
-            CompoundFile cf = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
-
-            CFStorage st = cf.RootStorage.AddStorage("MyStorage");
-            CFStream sm = st.AddStream("MyStream");
             byte[] b = Helpers.GetBuffer(227);
-            sm.SetData(b);
 
-            cf.SaveAs(filename);
-            cf.Close();
+            using (CompoundFile cf = new(CFSVersion.Ver_4, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors))
+            {
+                CFStorage st = cf.RootStorage.AddStorage("MyStorage");
+                CFStream sm = st.AddStream("MyStream");
+                sm.SetData(b);
 
-            CompoundFile cf2 = new CompoundFile(filename);
+                cf.SaveAs(filename);
+            }
+
+            using CompoundFile cf2 = new CompoundFile(filename);
             CFStorage st2 = cf2.RootStorage.GetStorage("MyStorage");
             CFStream sm2 = st2.GetStream("MyStream");
 
             Assert.IsNotNull(sm2);
             Assert.AreEqual(b.Length, sm2.Size);
-
-            cf2.Close();
         }
 
         [TestMethod]
@@ -185,17 +181,16 @@ namespace OpenMcdf.Test
             const string filename = "reportREAD.xls";
 
             using var fs = new FileStream(filename, FileMode.Open);
-            using var cf = new CompoundFile(fs);
+            using CompoundFile cf = new(fs);
             var foundStream = cf.RootStorage.GetStream("Workbook");
             var temp = foundStream.GetData();
             Assert.IsNotNull(temp);
-            cf.Close();
         }
 
         [TestMethod]
         public void Test_MULTIPLE_SAVE()
         {
-            var file = new CompoundFile();
+            using CompoundFile file = new();
 
             file.SaveAs("test.mdf");
 
@@ -212,7 +207,7 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_OPEN_COMPOUND_BUG_FIX_133()
         {
-            var f = new CompoundFile("testbad.ole");
+            using CompoundFile f = new("testbad.ole");
             CFStream cfs = f.RootStorage.GetStream("\x01Ole10Native");
             byte[] data = cfs.GetData();
             Assert.AreEqual(18140, data.Length);
@@ -221,26 +216,25 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_COMPARE_DIR_ENTRY_NAME_BUG_FIX_ID_3487353()
         {
-            var f = new CompoundFile("report_name_fix.xls", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
-            CFStream cfs = f.RootStorage.AddStream("Poorbook");
-            cfs.Append(Helpers.GetBuffer(20));
-            f.Commit();
-            f.Close();
+            using (CompoundFile f = new("report_name_fix.xls", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors))
+            {
+                CFStream cfs = f.RootStorage.AddStream("Poorbook");
+                cfs.Append(Helpers.GetBuffer(20));
+                f.Commit();
+            }
 
-            f = new CompoundFile("report_name_fix.xls", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
-            cfs = f.RootStorage.GetStream("Workbook");
-            Assert.AreEqual("Workbook", cfs.Name);
-            f.RootStorage.Delete("PoorBook");
-            f.Commit();
-            f.Close();
+            using CompoundFile f2 = new("report_name_fix.xls", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
+            var cfs2 = f2.RootStorage.GetStream("Workbook");
+            Assert.AreEqual("Workbook", cfs2.Name);
+            f2.RootStorage.Delete("PoorBook");
+            f2.Commit();
         }
 
         [TestMethod]
         public void Test_GET_COMPOUND_VERSION()
         {
-            var f = new CompoundFile("report_name_fix.xls");
+            using CompoundFile f = new("report_name_fix.xls");
             Assert.AreEqual(CFSVersion.Ver_3, f.Version);
-            f.Close();
         }
 
         [TestMethod]
@@ -267,69 +261,70 @@ namespace OpenMcdf.Test
             //############
 
             // Phase 1
-            var cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.AddStream("A").SetData(bA);
-            cf.SaveAs("OneStream.cfs");
-            cf.Close();
+            using (CompoundFile cf = new(CFSVersion.Ver_3, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.AddStream("A").SetData(bA);
+                cf.SaveAs("OneStream.cfs");
+            }
 
             // Test Phase 1
-            var cfTest = new CompoundFile("OneStream.cfs");
-            CFStream testSt = cfTest.RootStorage.GetStream("A");
+            using (CompoundFile cfTest = new("OneStream.cfs"))
+            {
+                CFStream testSt = cfTest.RootStorage.GetStream("A");
 
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bA, testSt.GetData());
-
-            cfTest.Close();
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bA, testSt.GetData());
+            }
 
             //###########
 
             //Phase 2
-            cf = new CompoundFile("OneStream.cfs", CFSUpdateMode.ReadOnly, CFSConfiguration.SectorRecycle);
+            using (CompoundFile cf = new("OneStream.cfs", CFSUpdateMode.ReadOnly, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.AddStream("B").SetData(bB);
+                cf.RootStorage.AddStream("C").SetData(bC);
+                cf.RootStorage.AddStream("D").SetData(bD);
+                cf.RootStorage.AddStream("E").SetData(bE);
+                cf.RootStorage.AddStream("F").SetData(bF);
+                cf.RootStorage.AddStream("G").SetData(bG);
+                cf.RootStorage.AddStream("H").SetData(bH);
 
-            cf.RootStorage.AddStream("B").SetData(bB);
-            cf.RootStorage.AddStream("C").SetData(bC);
-            cf.RootStorage.AddStream("D").SetData(bD);
-            cf.RootStorage.AddStream("E").SetData(bE);
-            cf.RootStorage.AddStream("F").SetData(bF);
-            cf.RootStorage.AddStream("G").SetData(bG);
-            cf.RootStorage.AddStream("H").SetData(bH);
-
-            cf.SaveAs("8_Streams.cfs");
-            cf.Close();
+                cf.SaveAs("8_Streams.cfs");
+            }
 
             // Test Phase 2
 
-            cfTest = new CompoundFile("8_Streams.cfs");
+            using (CompoundFile cfTest = new("8_Streams.cfs"))
+            {
+                CFStream testSt = cfTest.RootStorage.GetStream("B");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bB, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("B");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bB, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("C");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bC, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("C");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bC, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("D");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bD, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("D");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bD, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("E");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bE, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("E");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bE, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("F");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bF, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("F");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bF, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("G");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bG, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("G");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bG, testSt.GetData());
+                testSt = cfTest.RootStorage.GetStream("H");
+                Assert.IsNotNull(testSt);
+                CollectionAssert.AreEqual(bH, testSt.GetData());
 
-            testSt = cfTest.RootStorage.GetStream("H");
-            Assert.IsNotNull(testSt);
-            CollectionAssert.AreEqual(bH, testSt.GetData());
-
-            cfTest.Close();
+            }
 
             File.Copy("8_Streams.cfs", "6_Streams.cfs", true);
             File.Delete("8_Streams.cfs");
@@ -340,20 +335,20 @@ namespace OpenMcdf.Test
             Trace.Listeners.Add(new ConsoleTraceListener());
 #endif
             // Phase 3
-            cf = new CompoundFile("6_Streams.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors);
-            cf.RootStorage.Delete("D");
-            cf.RootStorage.Delete("G");
-            cf.Commit();
+            using (CompoundFile cf = new("6_Streams.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle | CFSConfiguration.EraseFreeSectors))
+            {
+                cf.RootStorage.Delete("D");
+                cf.RootStorage.Delete("G");
+                cf.Commit();
+            }
 
-            cf.Close();
+            // Test Phase 3
 
-            //Test Phase 3
-
-            cfTest = new CompoundFile("6_Streams.cfs");
-            Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStream("D"));
-            Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStream("G"));
-
-            cfTest.Close();
+            using (CompoundFile cfTest = new("6_Streams.cfs"))
+            {
+                Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStream("D"));
+                Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStream("G"));
+            }
 
             //##########
 
@@ -366,128 +361,130 @@ namespace OpenMcdf.Test
 
             Assert.IsTrue(new FileInfo("6_Streams_Shrinked.cfs").Length < new FileInfo("6_Streams.cfs").Length);
 
-            cfTest = new CompoundFile("6_Streams_Shrinked.cfs");
-            Action<CFItem> va = delegate (CFItem item)
+            using (CompoundFile cfTest = new("6_Streams_Shrinked.cfs"))
             {
-                if (item.IsStream)
+                Action<CFItem> va = delegate (CFItem item)
                 {
-                    CFStream ia = item as CFStream;
-                    Assert.IsNotNull(ia);
-                    Assert.IsTrue(ia.Size > 0);
-                    byte[] d = ia.GetData();
-                    Assert.IsNotNull(d);
-                    Assert.IsTrue(d.Length > 0);
-                    Assert.AreEqual(ia.Size, d.Length);
-                }
-            };
+                    if (item.IsStream)
+                    {
+                        CFStream ia = item as CFStream;
+                        Assert.IsNotNull(ia);
+                        Assert.IsTrue(ia.Size > 0);
+                        byte[] d = ia.GetData();
+                        Assert.IsNotNull(d);
+                        Assert.IsTrue(d.Length > 0);
+                        Assert.AreEqual(ia.Size, d.Length);
+                    }
+                };
 
-            cfTest.RootStorage.VisitEntries(va, true);
-            cfTest.Close();
+                cfTest.RootStorage.VisitEntries(va, true);
+            }
 
             //##########
 
             //Phase 5
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.AddStream("ZZZ").SetData(bF);
-            cf.RootStorage.GetStream("E").Append(bE2);
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.AddStream("ZZZ").SetData(bF);
+                cf.RootStorage.GetStream("E").Append(bE2);
+                cf.Commit();
+            }
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.CLSID = new Guid("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE");
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.CLSID = new Guid("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE");
+                cf.Commit();
+            }
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.AddStorage("MyStorage").AddStream("ZIP").Append(bE);
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.AddStorage("MyStorage").AddStream("ZIP").Append(bE);
+                cf.Commit();
+            }
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.AddStorage("AnotherStorage").AddStream("ANS").Append(bE);
-            cf.RootStorage.Delete("MyStorage");
-
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.AddStorage("AnotherStorage").AddStream("ANS").Append(bE);
+                cf.RootStorage.Delete("MyStorage");
+                cf.Commit();
+            }
 
             //Test Phase 5
 
             //#####
 
-            //Phase 6
+            // Phase 6
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            CFStorage root = cf.RootStorage;
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                CFStorage root = cf.RootStorage;
+                root.AddStorage("MiniStorage").AddStream("miniSt").Append(bMini);
+                root.GetStorage("MiniStorage").AddStream("miniSt2").Append(bMini);
+                cf.Commit();
+            }
 
-            root.AddStorage("MiniStorage").AddStream("miniSt").Append(bMini);
-
-            cf.RootStorage.GetStorage("MiniStorage").AddStream("miniSt2").Append(bMini);
-            cf.Commit();
-            cf.Close();
-
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            cf.RootStorage.GetStorage("MiniStorage").Delete("miniSt");
-
-            cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Append(bE);
-
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.GetStorage("MiniStorage").Delete("miniSt");
+                cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Append(bE);
+                cf.Commit();
+            }
 
             //Test Phase 6
 
-            cfTest = new CompoundFile("6_Streams_Shrinked.cfs");
-            byte[] d2 = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").GetData();
-            Assert.AreEqual(bE.Length + bMini.Length, d2.Length);
+            using (CompoundFile cfTest = new("6_Streams_Shrinked.cfs"))
+            {
+                byte[] d2 = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").GetData();
+                Assert.AreEqual(bE.Length + bMini.Length, d2.Length);
 
-            int cnt = 1;
-            byte[] buf = new byte[cnt];
-            cnt = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Read(buf, bMini.Length, cnt);
+                int cnt = 1;
+                byte[] buf = new byte[cnt];
+                cnt = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Read(buf, bMini.Length, cnt);
 
-            Assert.AreEqual(1, cnt);
-            Assert.AreEqual(0x1A, buf[0]);
+                Assert.AreEqual(1, cnt);
+                Assert.AreEqual(0x1A, buf[0]);
 
-            cnt = 1;
-            cnt = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Read(buf, bMini.Length - 1, cnt);
-            Assert.AreEqual(1, cnt);
-            Assert.AreEqual(0xEE, buf[0]);
+                cnt = 1;
+                cnt = cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").Read(buf, bMini.Length - 1, cnt);
+                Assert.AreEqual(1, cnt);
+                Assert.AreEqual(0xEE, buf[0]);
 
-            Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt"));
-
-            cfTest.Close();
+                Assert.ThrowsException<CFItemNotFound>(() => cfTest.RootStorage.GetStorage("MiniStorage").GetStream("miniSt"));
+            }
 
             //##############
 
             //Phase 7
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-
-            cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").SetData(bA);
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").SetData(bA);
+                cf.Commit();
+            }
 
             //Test Phase 7
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle);
-            d2 = cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").GetData();
-            Assert.IsNotNull(d2);
-            Assert.AreEqual(bA.Length, d2.Length);
-
-            cf.Close();
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.Update, CFSConfiguration.SectorRecycle))
+            {
+                var d2 = cf.RootStorage.GetStorage("MiniStorage").GetStream("miniSt2").GetData();
+                Assert.IsNotNull(d2);
+                Assert.AreEqual(bA.Length, d2.Length);
+            }
 
             //##############
 
-            cf = new CompoundFile("6_Streams_Shrinked.cfs", CFSUpdateMode.ReadOnly, CFSConfiguration.SectorRecycle);
+            using (CompoundFile cf = new("6_Streams_Shrinked.cfs", CFSUpdateMode.ReadOnly, CFSConfiguration.SectorRecycle))
+            {
 
-            var myStream = cf.RootStorage.GetStream("C");
-            var data = myStream.GetData();
-            Console.WriteLine(data[0] + " : " + data[data.Length - 1]);
+                var myStream = cf.RootStorage.GetStream("C");
+                var data = myStream.GetData();
+                Console.WriteLine(data[0] + " : " + data[data.Length - 1]);
 
-            myStream = cf.RootStorage.GetStream("B");
-            data = myStream.GetData();
-            Console.WriteLine(data[0] + " : " + data[data.Length - 1]);
-
-            cf.Close();
+                myStream = cf.RootStorage.GetStream("B");
+                data = myStream.GetData();
+                Console.WriteLine(data[0] + " : " + data[data.Length - 1]);
+            }
 
             sw.Stop();
             Console.WriteLine(sw.ElapsedMilliseconds);
@@ -496,7 +493,7 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_RETRIVE_ALL_NAMED_ENTRIES()
         {
-            var f = new CompoundFile("MultipleStorage4.cfs");
+            using CompoundFile f = new("MultipleStorage4.cfs");
             IList<CFItem> result = f.GetAllNamedEntries("MyStream");
 
             Assert.AreEqual(3, result.Count);
@@ -514,32 +511,29 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_DIFAT_CHECK()
         {
-            CompoundFile f = null;
             try
             {
-                f = new CompoundFile();
-                CFStream st = f.RootStorage.AddStream("LargeStream");
-                st.Append(Helpers.GetBuffer(20000000, 0x0A));       //Forcing creation of two DIFAT sectors
                 byte[] b1 = Helpers.GetBuffer(3, 0x0B);
-                st.Append(b1);                                      //Forcing creation of two DIFAT sectors
 
-                f.SaveAs("$OpenMcdf$LargeFile.cfs");
+                using (CompoundFile f = new())
+                {
+                    CFStream st = f.RootStorage.AddStream("LargeStream");
+                    st.Append(Helpers.GetBuffer(20000000, 0x0A));       // Forcing creation of two DIFAT sectors
+                    st.Append(b1);                                      // Forcing creation of two DIFAT sectors
 
-                f.Close();
+                    f.SaveAs("$OpenMcdf$LargeFile.cfs");
+                }
 
                 int cnt = 3;
-                f = new CompoundFile("$OpenMcdf$LargeFile.cfs");
-
-                byte[] b2 = new byte[cnt];
-                cnt = f.RootStorage.GetStream("LargeStream").Read(b2, 20000000, cnt);
-                f.Close();
-                CollectionAssert.AreEqual(b1, b2);
+                using (CompoundFile f = new("$OpenMcdf$LargeFile.cfs"))
+                {
+                    byte[] b2 = new byte[cnt];
+                    cnt = f.RootStorage.GetStream("LargeStream").Read(b2, 20000000, cnt);
+                    CollectionAssert.AreEqual(b1, b2);
+                }
             }
             finally
             {
-                if (f != null)
-                    f.Close();
-
                 File.Delete("$OpenMcdf$LargeFile.cfs");
             }
         }
@@ -551,26 +545,24 @@ namespace OpenMcdf.Test
             byte[] buffer = Helpers.GetBuffer(10, 0x0A);
             try
             {
-                CompoundFile f = new CompoundFile();
-
-                for (int i = 0; i < ITEM_NUMBER; i++)
+                using (CompoundFile f = new())
                 {
-                    CFStream st = f.RootStorage.AddStream("Stream" + i.ToString());
-                    st.Append(buffer);
+                    for (int i = 0; i < ITEM_NUMBER; i++)
+                    {
+                        CFStream st = f.RootStorage.AddStream("Stream" + i.ToString());
+                        st.Append(buffer);
+                    }
+
+                    File.Delete("$ItemsLargeNumber.cfs");
+                    f.SaveAs("$ItemsLargeNumber.cfs");
                 }
 
-                if (File.Exists("$ItemsLargeNumber.cfs"))
-                    File.Delete("$ItemsLargeNumber.cfs");
-
-                f.SaveAs("$ItemsLargeNumber.cfs");
-                f.Close();
-
-                f = new CompoundFile("$ItemsLargeNumber.cfs");
-                CFStream cfs = f.RootStorage.GetStream("Stream" + (ITEM_NUMBER / 2).ToString());
-
-                Assert.IsNotNull(cfs, "Item is null");
-                CollectionAssert.AreEqual(buffer, cfs.GetData());
-                f.Close();
+                using (CompoundFile f = new("$ItemsLargeNumber.cfs"))
+                {
+                    CFStream cfs = f.RootStorage.GetStream("Stream" + (ITEM_NUMBER / 2).ToString());
+                    Assert.IsNotNull(cfs, "Item is null");
+                    CollectionAssert.AreEqual(buffer, cfs.GetData());
+                }
             }
             finally
             {
@@ -583,7 +575,7 @@ namespace OpenMcdf.Test
         {
             const string FILE_PATH = @"BUG_16_.xls";
 
-            CompoundFile cf = new CompoundFile(FILE_PATH);
+            using CompoundFile cf = new(FILE_PATH);
 
             CFStream dirStream = cf.RootStorage.GetStorage("_VBA_PROJECT_CUR").GetStorage("VBA").GetStream("dir");
 
@@ -594,7 +586,6 @@ namespace OpenMcdf.Test
             dirStream.SetData(currentData);
 
             cf.SaveAs(FILE_PATH + ".edited");
-            cf.Close();
         }
 
         [TestMethod]
@@ -610,26 +601,17 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_FIX_BUG_24_CORRUPTED_THUMBS_DB_FILE()
         {
-            try
+            Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
-                using var cf = new CompoundFile("_thumbs_bug_24.db");
+                using CompoundFile cf = new("_thumbs_bug_24.db");
                 cf.RootStorage.VisitEntries(item => Console.WriteLine(item.Name), recursive: false);
-            }
-            catch (Exception exc)
-            {
-                Assert.IsInstanceOfType(exc, typeof(CFCorruptedFileException));
-            }
-
-            using (var cf = new CompoundFile("report.xls"))
-            {
-                cf.RootStorage.VisitEntries(item => Console.WriteLine(item.Name), recursive: false);
-            }
+            });
         }
 
         [TestMethod]
         public void Test_FIX_BUG_28_CompoundFile_Delete_ChildElementMaintainsFiles()
         {
-            using var compoundFile = new CompoundFile();
+            using CompoundFile compoundFile = new();
             var storage1 = compoundFile.RootStorage.AddStorage("A");
             var storage2 = compoundFile.RootStorage.AddStorage("B");
             var storage3 = compoundFile.RootStorage.AddStorage("C");
@@ -642,16 +624,14 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_CORRUPTEDDOC_BUG36_SHOULD_THROW_CORRUPTED_FILE_EXCEPTION()
         {
-            FileStream fs = null;
-            try
+            using FileStream fs = new("CorruptedDoc_bug36.doc", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+            Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
-                fs = new FileStream("CorruptedDoc_bug36.doc", FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
-                CompoundFile file = new CompoundFile(fs, CFSUpdateMode.ReadOnly, CFSConfiguration.LeaveOpen);
-            }
-            catch (Exception)
-            {
-                Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
-            }
+                using CompoundFile file = new(fs, CFSUpdateMode.ReadOnly, CFSConfiguration.LeaveOpen);
+            });
+
+            Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
         }
 
         [TestMethod]
@@ -659,22 +639,22 @@ namespace OpenMcdf.Test
         {
             File.Delete("TEST_ISSUE_2");
 
-            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
-            var s = cf.RootStorage.AddStream("miniToNormal");
-            s.Append(Helpers.GetBuffer(4090, 0xAA));
+            using (CompoundFile cf = new(CFSVersion.Ver_3, CFSConfiguration.Default))
+            {
+                var s = cf.RootStorage.AddStream("miniToNormal");
+                s.Append(Helpers.GetBuffer(4090, 0xAA));
+                cf.SaveAs("TEST_ISSUE_2");
+            }
 
-            cf.SaveAs("TEST_ISSUE_2");
-            cf.Close();
-            var cf2 = new CompoundFile("TEST_ISSUE_2", CFSUpdateMode.Update, CFSConfiguration.Default);
+            using CompoundFile cf2 = new("TEST_ISSUE_2", CFSUpdateMode.Update, CFSConfiguration.Default);
             cf2.RootStorage.GetStream("miniToNormal").Append(Helpers.GetBuffer(6, 0xBB));
             cf2.Commit();
-            cf2.Close();
         }
 
         [TestMethod]
         public void Test_PR_13()
         {
-            CompoundFile cf = new CompoundFile("report.xls");
+            using CompoundFile cf = new("report.xls");
             Guid g = cf.getGuidBySID(0);
             Assert.IsNotNull(g);
             g = cf.getGuidForStream(3);
@@ -690,7 +670,7 @@ namespace OpenMcdf.Test
         //    CompoundFile cf = null;
         //    try
         //    {
-        //        cf = new CompoundFile("CiclycDFAT.cfs");
+        //        using (CompoundFile cf = new("CiclycDFAT.cfs");
         //        CFStorage s = cf.RootStorage.GetStorage("MyStorage");
         //        CFStream st = s.GetStream("MyStream");
         //        Assert.IsTrue(st.Size > 0);
@@ -722,15 +702,12 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_COPY_ENTRIES_FROM_TO_STORAGE()
         {
-            CompoundFile cfDst = new CompoundFile();
-            CompoundFile cfSrc = new CompoundFile("MultipleStorage4.cfs");
+            using CompoundFile cfDst = new();
+            using CompoundFile cfSrc = new("MultipleStorage4.cfs");
 
             Copy(cfSrc.RootStorage, cfDst.RootStorage);
 
             cfDst.SaveAs("MultipleStorage4Copy.cfs");
-
-            cfDst.Close();
-            cfSrc.Close();
         }
 
         #region Copy helper method
@@ -771,44 +748,45 @@ namespace OpenMcdf.Test
             int iterationCount = 1;
             int streamCount = 3;
 
-            CompoundFile compoundFileInit = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.Default);
-            compoundFileInit.SaveAs(filename);
-            compoundFileInit.Close();
-
-            CompoundFile compoundFile = new CompoundFile(filename, CFSUpdateMode.Update, CFSConfiguration.Default);
-            CFStorage st = compoundFile.RootStorage.AddStorage(storageName);
-            byte b = 0X0A;
-
-            for (int streamId = 0; streamId < streamCount; ++streamId)
+            using (CompoundFile compoundFileInit = new(CFSVersion.Ver_4, CFSConfiguration.Default))
             {
-                CFStream sm = st.AddStream(streamName + streamId);
-                for (int iteration = 0; iteration < iterationCount; ++iteration)
+                compoundFileInit.SaveAs(filename);
+            }
+
+            using (CompoundFile compoundFile = new(filename, CFSUpdateMode.Update, CFSConfiguration.Default))
+            {
+                CFStorage st = compoundFile.RootStorage.AddStorage(storageName);
+                byte b = 0X0A;
+
+                for (int streamId = 0; streamId < streamCount; ++streamId)
                 {
-                    sm.Append(Helpers.GetBuffer(BUFFER_SIZE, b));
-                    compoundFile.Commit();
+                    CFStream sm = st.AddStream(streamName + streamId);
+                    for (int iteration = 0; iteration < iterationCount; ++iteration)
+                    {
+                        sm.Append(Helpers.GetBuffer(BUFFER_SIZE, b));
+                        compoundFile.Commit();
+                    }
+
+                    b++;
                 }
-
-                b++;
             }
 
-            compoundFile.Close();
-
-            compoundFile = new CompoundFile(filename, CFSUpdateMode.ReadOnly, CFSConfiguration.Default);
-            byte[] testBuffer = new byte[100];
-            byte t = 0x0A;
-
-            for (int streamId = 0; streamId < streamCount; ++streamId)
+            using (CompoundFile compoundFile = new(filename, CFSUpdateMode.ReadOnly, CFSConfiguration.Default))
             {
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, BUFFER_SIZE / 2, 100);
-                Assert.IsTrue(testBuffer.All(g => g == t));
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, BUFFER_SIZE - 101, 100);
-                Assert.IsTrue(testBuffer.All(g => g == t));
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, 0, 100);
-                Assert.IsTrue(testBuffer.All(g => g == t));
-                t++;
-            }
+                byte[] testBuffer = new byte[100];
+                byte t = 0x0A;
 
-            compoundFile.Close();
+                for (int streamId = 0; streamId<streamCount; ++streamId)
+                {
+                    compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, BUFFER_SIZE / 2, 100);
+                    Assert.IsTrue(testBuffer.All(g => g == t));
+                    compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, BUFFER_SIZE - 101, 100);
+                    Assert.IsTrue(testBuffer.All(g => g == t));
+                    compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + streamId).Read(testBuffer, 0, 100);
+                    Assert.IsTrue(testBuffer.All(g => g == t));
+                    t++;
+                }
+            }
         }
 
         [TestMethod]
@@ -821,45 +799,47 @@ namespace OpenMcdf.Test
             int iterationCount = 1;
             int streamCount = 1;
 
-            CompoundFile compoundFile = new CompoundFile(CFSVersion.Ver_4, CFSConfiguration.Default);
-            CFStorage st = compoundFile.RootStorage.AddStorage(storageName);
-
-            for (int streamId = 0; streamId < streamCount; ++streamId)
+            using (CompoundFile compoundFile = new(CFSVersion.Ver_4, CFSConfiguration.Default))
             {
-                CFStream sm = st.AddStream(streamName + streamId);
-                for (int iteration = 0; iteration < iterationCount; ++iteration)
+                CFStorage st = compoundFile.RootStorage.AddStorage(storageName);
+
+                for (int streamId = 0; streamId < streamCount; ++streamId)
                 {
-                    byte b = (byte)(0x0A + iteration);
-                    sm.Append(Helpers.GetBuffer(BUFFER_SIZE, b));
+                    CFStream sm = st.AddStream(streamName + streamId);
+                    for (int iteration = 0; iteration < iterationCount; ++iteration)
+                    {
+                        byte b = (byte)(0x0A + iteration);
+                        sm.Append(Helpers.GetBuffer(BUFFER_SIZE, b));
+                    }
+                }
+
+                compoundFile.SaveAs(filename);
+            }
+
+            using (CompoundFile compoundFile = new(filename))
+            {
+                byte c = 0x0A;
+                byte[] readBuffer = new byte[15];
+                CFStorage storage = compoundFile.RootStorage.GetStorage(storageName);
+                for (int i = 0; i < iterationCount; i++)
+                {
+                    Array.Clear(readBuffer, 0, readBuffer.Length);
+                    CFStream stream = storage.GetStream($"{streamName}{0}");
+                    stream.Read(readBuffer, BUFFER_SIZE + ((long)BUFFER_SIZE * i) - 15, 15);
+                    Assert.IsTrue(readBuffer.All(by => by == c));
+                    c++;
                 }
             }
-
-            compoundFile.SaveAs(filename);
-            compoundFile.Close();
-
-            byte[] readBuffer = new byte[15];
-            compoundFile = new CompoundFile(filename);
-
-            byte c = 0x0A;
-            for (int i = 0; i < iterationCount; i++)
-            {
-                compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName + 0.ToString()).Read(readBuffer, BUFFER_SIZE + ((long)BUFFER_SIZE * i) - 15, 15);
-                Assert.IsTrue(readBuffer.All(by => by == c));
-                c++;
-            }
-
-            compoundFile.Close();
         }
 
         [TestMethod]
         public void Test_PR_GH_18()
         {
-            var f = new CompoundFile("MultipleStorage4.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
+            using CompoundFile f = new("MultipleStorage4.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
             var st = f.RootStorage.GetStorage("MyStorage").GetStorage("AnotherStorage").GetStream("MyStream");
             st.Write(Helpers.GetBuffer(100, 0x02), 100);
             f.Commit(true);
             Assert.AreEqual(31220, st.GetData().Length);
-            f.Close();
         }
 
         [TestMethod]
@@ -893,20 +873,19 @@ namespace OpenMcdf.Test
             {
                 byte[] bigDataBuffer = Helpers.GetBuffer(1024 * 1024 * 260);
 
-                using FileStream fTest = new FileStream("BigFile.data", FileMode.Create);
-                fTest.Write(bigDataBuffer, 0, 1024 * 1024 * 260);
-                fTest.Flush();
-                fTest.Close();
+                using (FileStream fTest = new("BigFile.data", FileMode.Create))
+                {
+                    fTest.Write(bigDataBuffer, 0, 1024 * 1024 * 260);
+                }
 
-                var f = new CompoundFile();
+                using CompoundFile f = new();
                 var cfStream = f.RootStorage.AddStream("NewStream");
-                using (FileStream fs = new FileStream("BigFile.data", FileMode.Open))
+                using (FileStream fs = new("BigFile.data", FileMode.Open))
                 {
                     cfStream.CopyFrom(fs);
                 }
 
                 f.SaveAs("BigFile.cfs");
-                f.Close();
             }
             finally
             {
@@ -919,24 +898,20 @@ namespace OpenMcdf.Test
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Doc()
         {
-            var f = new CompoundFile("corrupted-sector-chain.doc");
-
-            f.Close();
+            using CompoundFile f = new("corrupted-sector-chain.doc");
         }
 
         [TestMethod]
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Cfs()
         {
-            var f = new CompoundFile("corrupted-sector-chain.cfs");
-
-            f.Close();
+            using CompoundFile f = new("corrupted-sector-chain.cfs");
         }
 
         [TestMethod]
         public void Test_WRONG_CORRUPTED_EXCEPTION()
         {
-            var cf = new CompoundFile();
+            using CompoundFile cf = new();
 
             for (int i = 0; i < 100; i++)
             {
@@ -945,21 +920,15 @@ namespace OpenMcdf.Test
 
             cf.RootStorage.AddStream("BigStream").SetData(Helpers.GetBuffer(5250000, 0xAA));
 
-            using (var stream = new MemoryStream())
-            {
-                cf.Save(stream);
-            }
-
-            cf.Close();
+            using var stream = new MemoryStream();
+            cf.Save(stream);
         }
 
         [TestMethod]
         [ExpectedException(typeof(CFCorruptedFileException))]
         public void Test_CorruptedSectorChain_Doc2()
         {
-            var f = new CompoundFile("corrupted-sector-chain-2.doc");
-
-            f.Close();
+            using CompoundFile f = new("corrupted-sector-chain-2.doc");
         }
 
         //[TestMethod]
@@ -969,7 +938,7 @@ namespace OpenMcdf.Test
         //    CompoundFile cf = null;
         //    try
         //    {
-        //        cf = new CompoundFile("CiclycDFAT.cfs");
+        //        CompoundFile cf = new("CiclycDFAT.cfs");
         //        CFStorage s = cf.RootStorage.GetStorage("MyStorage");
         //        CFStream st = s.GetStream("MyStream");
         //        Assert.IsTrue(st.Size > 0);
@@ -999,47 +968,50 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_FIX_BUG_90_CompoundFile_Delete_Storages()
         {
-            using var compoundFile = new CompoundFile();
-            var root = compoundFile.RootStorage;
+            using var memStream = new MemoryStream();
             var storageNames = new HashSet<string>();
 
-            // add 99 storages to root
-            for (int i = 1; i <= 99; i++)
+            using (CompoundFile compoundFile = new())
             {
-                var name = "Storage " + i;
-                root.AddStorage(name);
-                storageNames.Add(name);
-            }
+                var root = compoundFile.RootStorage;
 
-            // remove storages until tree becomes unbalanced and its Root changes
-            var rootChild = root.DirEntry.Child;
-            var newChild = rootChild;
-            var j = 1;
-            while (newChild == rootChild && j <= 99)
-            {
-                var name = "Storage " + j;
-                root.Delete(name);
-                storageNames.Remove(name);
-                newChild = ((DirectoryEntry)root.Children.Root).SID; // stop as soon as root.Children has a new Root
-                j++;
-            }
+                // add 99 storages to root
+                for (int i = 1; i <= 99; i++)
+                {
+                    var name = "Storage " + i;
+                    root.AddStorage(name);
+                    storageNames.Add(name);
+                }
 
-            // check if all remaining storages are still there
-            foreach (var storageName in storageNames)
-            {
-                Assert.IsTrue(root.TryGetStorage(storageName, out var storage)); // <- no problem here
-            }
+                // remove storages until tree becomes unbalanced and its Root changes
+                var rootChild = root.DirEntry.Child;
+                var newChild = rootChild;
+                var j = 1;
+                while (newChild == rootChild && j <= 99)
+                {
+                    var name = "Storage " + j;
+                    root.Delete(name);
+                    storageNames.Remove(name);
+                    newChild = ((DirectoryEntry)root.Children.Root).SID; // stop as soon as root.Children has a new Root
+                    j++;
+                }
 
-            // write CompundFile into MemoryStream...
-            using var memStream = new MemoryStream();
-            compoundFile.Save(memStream);
+                // check if all remaining storages are still there
+                foreach (var storageName in storageNames)
+                {
+                    Assert.IsTrue(root.TryGetStorage(storageName, out var storage)); // <- no problem here
+                }
+
+                // write CompundFile into MemoryStream...
+                compoundFile.Save(memStream);
+            }
 
             // ....and read new CompundFile from that stream
-            using var newCf = new CompoundFile(memStream);
+            using CompoundFile cf = new(memStream);
             // check if all storages can be found in to copied CompundFile
             foreach (var storageName in storageNames)
             {
-                Assert.IsTrue(newCf.RootStorage.TryGetStorage(storageName, out var storage)); //<- we will see some missing storages here
+                Assert.IsTrue(cf.RootStorage.TryGetStorage(storageName, out var storage)); //<- we will see some missing storages here
             }
         }
 
@@ -1048,7 +1020,7 @@ namespace OpenMcdf.Test
         {
             Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
-                var cf = new CompoundFile("mediationform.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default & ~CFSConfiguration.NoValidationException);
+                using CompoundFile cf = new("mediationform.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default & ~CFSConfiguration.NoValidationException);
                 var s = cf.RootStorage.GetStream("\u0001CompObj");
                 byte[] data = s.GetData();
             });
@@ -1062,10 +1034,11 @@ namespace OpenMcdf.Test
 
             File.Copy(filename, filename2, true);
 
-            var cf = new CompoundFile(filename2, CFSUpdateMode.Update, CFSConfiguration.EraseFreeSectors);
-            cf.RootStorage.Delete("PowerPoint Document");
-            cf.Commit();
-            cf.Close();
+            using (CompoundFile cf = new(filename2, CFSUpdateMode.Update, CFSConfiguration.EraseFreeSectors))
+            {
+                cf.RootStorage.Delete("PowerPoint Document");
+                cf.Commit();
+            }
 
             CompoundFile.ShrinkCompoundFile(filename2);
 
@@ -1093,7 +1066,6 @@ namespace OpenMcdf.Test
                 var s = compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName);
                 s.Write(new byte[] { 0x0A, 0x0A }, 0);
                 compoundFile.SaveAs(filename2);
-                compoundFile.Close();
             });
 
             Assert.ThrowsException<CFException>(() =>
@@ -1103,17 +1075,15 @@ namespace OpenMcdf.Test
                 var s = compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName);
                 s.Write(new byte[] { 0x0A, 0x0A }, 0);
                 compoundFile.SaveAs(rootedPath);
-                compoundFile.Close();
             });
 
             Assert.ThrowsException<CFException>(() =>
             {
-                using CompoundFile compoundFile = new CompoundFile(filename2);
+                using CompoundFile compoundFile = new(filename2);
                 using FileStream fs = new(filename2, FileMode.Open);
                 var s = compoundFile.RootStorage.GetStorage(storageName).GetStream(streamName);
                 s.Write(new byte[] { 0x0A, 0x0A }, 0);
                 compoundFile.Save(fs);
-                compoundFile.Close();
             });
 
             File.Delete(filename2);

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -881,55 +881,27 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_PR_GH_18()
         {
-            try
-            {
-                var f = new CompoundFile("MultipleStorage4.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
-                var st = f.RootStorage.GetStorage("MyStorage").GetStorage("AnotherStorage").GetStream("MyStream");
-                st.Write(Helpers.GetBuffer(100, 0x02), 100);
-                f.Commit(true);
-                Assert.AreEqual(31220, st.GetData().Length);
-                f.Close();
-            }
-            catch (Exception)
-            {
-                Assert.Fail("Release Memory flag caused error");
-            }
+            var f = new CompoundFile("MultipleStorage4.cfs", CFSUpdateMode.Update, CFSConfiguration.Default);
+            var st = f.RootStorage.GetStorage("MyStorage").GetStorage("AnotherStorage").GetStream("MyStream");
+            st.Write(Helpers.GetBuffer(100, 0x02), 100);
+            f.Commit(true);
+            Assert.AreEqual(31220, st.GetData().Length);
+            f.Close();
         }
 
         [TestMethod]
         public void Test_FIX_GH_38()
         {
-            CompoundFile f = null;
-            try
+            Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
-                f = new CompoundFile("empty_directory_chain.doc", CFSUpdateMode.Update, CFSConfiguration.Default);
-
-                f.Close();
-            }
-            catch (Exception ex)
-            {
-                Assert.IsInstanceOfType(ex, typeof(CFCorruptedFileException));
-                if (f != null)
-                    f.Close();
-            }
+                using CompoundFile f = new("empty_directory_chain.doc", CFSUpdateMode.Update, CFSConfiguration.Default);
+            });
         }
 
         [TestMethod]
         public void Test_FIX_GH_38_B()
         {
-            CompoundFile f = null;
-            try
-            {
-                f = new CompoundFile("no_sectors.doc", CFSUpdateMode.Update, CFSConfiguration.Default);
-
-                f.Close();
-            }
-            catch (Exception ex)
-            {
-                Assert.IsInstanceOfType(ex, typeof(CFException));
-                if (f != null)
-                    f.Close();
-            }
+            Assert.ThrowsException<CFCorruptedFileException>(() => new CompoundFile("no_sectors.doc", CFSUpdateMode.Update, CFSConfiguration.Default));
         }
 
         [TestMethod]
@@ -1116,16 +1088,12 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_FIX_BUG_75_ForeverLoop()
         {
-            try
+            Assert.ThrowsException<CFCorruptedFileException>(() =>
             {
                 var cf = new CompoundFile("mediationform.doc", CFSUpdateMode.ReadOnly, CFSConfiguration.Default & ~CFSConfiguration.NoValidationException);
                 var s = cf.RootStorage.GetStream("\u0001CompObj");
                 byte[] data = s.GetData();
-            }
-            catch (Exception ex)
-            {
-                Assert.IsInstanceOfType(ex, typeof(CFCorruptedFileException));
-            }
+            });
         }
 
         [TestMethod]

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -577,14 +577,9 @@ namespace OpenMcdf.Test
                 CollectionAssert.AreEqual(buffer, cfs.GetData());
                 f.Close();
             }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.Message);
-            }
             finally
             {
-                //if (File.Exists("$ItemsLargeNumber.cfs"))
-                //    File.Delete("$ItemsLargeNumber.cfs");
+                File.Delete("$ItemsLargeNumber.cfs");
             }
         }
 
@@ -673,29 +668,21 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_ISSUE_2_WRONG_CUTOFF_SIZE()
         {
-            FileStream fs = null;
-            try
+            if (File.Exists("TEST_ISSUE_2"))
             {
-                if (File.Exists("TEST_ISSUE_2"))
-                {
-                    File.Delete("TEST_ISSUE_2");
-                }
-
-                CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
-                var s = cf.RootStorage.AddStream("miniToNormal");
-                s.Append(Helpers.GetBuffer(4090, 0xAA));
-
-                cf.SaveAs("TEST_ISSUE_2");
-                cf.Close();
-                var cf2 = new CompoundFile("TEST_ISSUE_2", CFSUpdateMode.Update, CFSConfiguration.Default);
-                cf2.RootStorage.GetStream("miniToNormal").Append(Helpers.GetBuffer(6, 0xBB));
-                cf2.Commit();
-                cf2.Close();
+                File.Delete("TEST_ISSUE_2");
             }
-            catch (Exception)
-            {
-                Assert.IsTrue(fs.CanRead && fs.CanSeek && fs.CanWrite);
-            }
+
+            CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
+            var s = cf.RootStorage.AddStream("miniToNormal");
+            s.Append(Helpers.GetBuffer(4090, 0xAA));
+
+            cf.SaveAs("TEST_ISSUE_2");
+            cf.Close();
+            var cf2 = new CompoundFile("TEST_ISSUE_2", CFSUpdateMode.Update, CFSConfiguration.Default);
+            cf2.RootStorage.GetStream("miniToNormal").Append(Helpers.GetBuffer(6, 0xBB));
+            cf2.Commit();
+            cf2.Close();
         }
 
         [TestMethod]
@@ -936,10 +923,6 @@ namespace OpenMcdf.Test
                     f.SaveAs("BigFile.cfs");
                     f.Close();
                 }
-            }
-            catch (Exception)
-            {
-                Assert.Fail();
             }
             finally
             {

--- a/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
+++ b/sources/Test/OpenMcdf.Test/CompoundFileTest.cs
@@ -544,8 +544,7 @@ namespace OpenMcdf.Test
                 if (f != null)
                     f.Close();
 
-                if (File.Exists("$OpenMcdf$LargeFile.cfs"))
-                    File.Delete("$OpenMcdf$LargeFile.cfs");
+                File.Delete("$OpenMcdf$LargeFile.cfs");
             }
         }
 
@@ -668,10 +667,7 @@ namespace OpenMcdf.Test
         [TestMethod]
         public void Test_ISSUE_2_WRONG_CUTOFF_SIZE()
         {
-            if (File.Exists("TEST_ISSUE_2"))
-            {
-                File.Delete("TEST_ISSUE_2");
-            }
+            File.Delete("TEST_ISSUE_2");
 
             CompoundFile cf = new CompoundFile(CFSVersion.Ver_3, CFSConfiguration.Default);
             var s = cf.RootStorage.AddStream("miniToNormal");
@@ -926,11 +922,8 @@ namespace OpenMcdf.Test
             }
             finally
             {
-                if (File.Exists("BigFile.data"))
-                    File.Delete("BigFile.data");
-
-                if (File.Exists("BigFile.cfs"))
-                    File.Delete("BigFile.cfs");
+                File.Delete("BigFile.data");
+                File.Delete("BigFile.cfs");
             }
         }
 
@@ -1085,13 +1078,7 @@ namespace OpenMcdf.Test
             string filename = "_Test.ppt";
             string filename2 = "MyFile4.dat";
 
-            if (File.Exists(filename2))
-                File.Delete(filename2);
-
-            if (File.Exists(filename))
-            {
-                File.Copy(filename, filename2);
-            }
+            File.Copy(filename, filename2, true);
 
             var cf = new CompoundFile(filename2, CFSUpdateMode.Update, CFSConfiguration.EraseFreeSectors);
             cf.RootStorage.Delete("PowerPoint Document");
@@ -1105,8 +1092,7 @@ namespace OpenMcdf.Test
 
             Assert.IsTrue(length > length2);
 
-            if (File.Exists(filename2))
-                File.Delete(filename2);
+            File.Delete(filename2);
         }
 
         [TestMethod]
@@ -1117,13 +1103,7 @@ namespace OpenMcdf.Test
             string storageName = "MyStorage";
             string streamName = "MyStream";
 
-            if (File.Exists(filename2))
-                File.Delete(filename2);
-
-            if (File.Exists(filename))
-            {
-                File.Copy(filename, filename2);
-            }
+            File.Copy(filename, filename2, true);
 
             Assert.ThrowsException<CFException>(() =>
             {
@@ -1154,9 +1134,7 @@ namespace OpenMcdf.Test
                 compoundFile.Close();
             });
 
-
-            if (File.Exists(filename2))
-                File.Delete(filename2);
+            File.Delete(filename2);
         }
     }
 }

--- a/sources/Test/OpenMcdf.Test/RBTreeTest.cs
+++ b/sources/Test/OpenMcdf.Test/RBTreeTest.cs
@@ -85,16 +85,9 @@ namespace OpenMcdf.Test
                 rbTree.Insert(item);
             }
 
-            try
-            {
-                rbTree.Delete(DirectoryEntry.Mock("5", StgType.StgInvalid), out IRBNode n);
-                rbTree.Delete(DirectoryEntry.Mock("24", StgType.StgInvalid), out n);
-                rbTree.Delete(DirectoryEntry.Mock("7", StgType.StgInvalid), out n);
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail("Item removal failed: " + ex.Message);
-            }
+            rbTree.Delete(DirectoryEntry.Mock("5", StgType.StgInvalid), out IRBNode n);
+            rbTree.Delete(DirectoryEntry.Mock("24", StgType.StgInvalid), out n);
+            rbTree.Delete(DirectoryEntry.Mock("7", StgType.StgInvalid), out n);
 
             //    CFItem c;
             //    bool s = rbTree.TryLookup(new CFMock("7", StgType.StgStream), out c);


### PR DESCRIPTION
The counterpart to fixing CA2000 in the core library, this fixes some more test implementation logic (e.g. more Assert.ThrowsException, etc.), removes redundant code, and fixes CA2000 for the tests