### PR TITLE
Remove a couple of private property setters in OLEPropertiesContainer

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -14,10 +14,10 @@ namespace OpenMcdf.Extensions.OLEProperties
 
         public bool HasUserDefinedProperties { get; private set; }
 
-        public ContainerType ContainerType { get; internal set; }
+        public ContainerType ContainerType { get; }
         private Guid? FmtID0 { get; }
 
-        public PropertyContext Context { get; private set; }
+        public PropertyContext Context { get; }
 
         private readonly List<OLEProperty> properties = new List<OLEProperty>();
         internal CFStream cfStream;
@@ -125,8 +125,6 @@ namespace OpenMcdf.Extensions.OLEProperties
             {
                 UserDefinedProperties = new OLEPropertiesContainer(pStream.PropertySet1.PropertyContext.CodePage, ContainerType.UserDefinedProperties);
                 HasUserDefinedProperties = true;
-
-                UserDefinedProperties.ContainerType = ContainerType.UserDefinedProperties;
 
                 for (int i = 0; i < pStream.PropertySet1.Properties.Count; i++)
                 {


### PR DESCRIPTION
Pulling in a couple of minor changes from my other PRs - I don't think these would be counted as API changes as they're private anyway, but that can be confirmed by others.

I don't think these should be settable - ContainerType is set on consturction and I don't think you'd want to change that afterwards, and I don't think there is a need for the context to be replaced - the properties inside it can be changed if needed