### PR TITLE
Try using GitHubActionsTestLogger to publish test results in the CI b…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,8 +36,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration ${{env.buildConfiguration}} -f ${{env.libFramework}} ${{env.buildProject}}
     - name: Test
-      run: dotnet test -f ${{env.appFramework}}  ${{env.testsProject}} --filter="${{env.testFilter}}"
+      run: dotnet test -f ${{env.appFramework}}  ${{env.testsProject}} --filter="${{env.testFilter}}" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
     - name: Test Extensions  
-      run: dotnet test -f ${{env.appFramework}}  ${{env.extensionTestsProject}}
-      
+      run: dotnet test -f ${{env.appFramework}}  ${{env.extensionTestsProject}} --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+
+
       

--- a/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
+++ b/sources/Test/OpenMcdf.Extensions.Test/OpenMcdf.Extensions.Test.csproj
@@ -16,7 +16,9 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net45'))"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"/>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>

--- a/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
+++ b/sources/Test/OpenMcdf.Test/OpenMcdf.Test.csproj
@@ -75,7 +75,9 @@
     <ProjectReference Include="..\..\OpenMcdf\OpenMcdf.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net45'))"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))"/>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>


### PR DESCRIPTION
…uilds

I haven't tried doing this before, so not sure if it needs any more setup

It currently conditionally includes the GitHubActionsTestLogger in the .NET 6.0 test build as it requires .NET 4.6.2 for Framework builds, and the test projects are currently build as .NET Framework 4.5.0