### PR TITLE
Fix and simplify DirectoryEntry validation

### DIFF
--- a/sources/OpenMcdf/CFStorage.cs
+++ b/sources/OpenMcdf/CFStorage.cs
@@ -53,16 +53,7 @@ namespace OpenMcdf
             get
             {
                 // Lazy loading of children tree.
-                if (children == null)
-                {
-                    //if (this.CompoundFile.HasSourceStream)
-                    //{
-                    children = LoadChildren(DirEntry.SID);
-                    //}
-                    //else
-                    children ??= new RBTree();
-                }
-
+                children ??= LoadChildren(DirEntry);
                 return children;
             }
         }
@@ -81,15 +72,10 @@ namespace OpenMcdf
             DirEntry = dirEntry;
         }
 
-        private RBTree LoadChildren(int SID)
+        private RBTree LoadChildren(IDirectoryEntry directoryEntry)
         {
-            RBTree childrenTree = CompoundFile.GetChildrenTree(SID);
-
-            if (childrenTree.Root != null)
-                DirEntry.Child = (childrenTree.Root as IDirectoryEntry).SID;
-            else
-                DirEntry.Child = DirectoryEntry.NOSTREAM;
-
+            RBTree childrenTree = CompoundFile.GetChildrenTree(directoryEntry);
+            DirEntry.Child = childrenTree.Root == null ? DirectoryEntry.NOSTREAM : ((IDirectoryEntry)childrenTree.Root).SID;
             return childrenTree;
         }
 
@@ -566,9 +552,7 @@ namespace OpenMcdf
             else throw new CFItemNotFound("Item " + oldItemName + " not found in Storage");
 
             children = null;
-            children = LoadChildren(DirEntry.SID); //Rethread
-
-            children ??= new RBTree();
+            children = LoadChildren(DirEntry); // Rethread
         }
     }
 }

--- a/sources/OpenMcdf/CompoundFile.cs
+++ b/sources/OpenMcdf/CompoundFile.cs
@@ -1502,42 +1502,10 @@ namespace OpenMcdf
 
         internal RBTree GetChildrenTree(IDirectoryEntry entry)
         {
-            RBTree bst = new RBTree();
-
-            // Load children from their original tree.
-            LoadChildren(bst, entry);
-            //bst = DoLoadChildrenTrusted(directoryEntries[sid]);
-
-            //bst.Print();
-            //bst.Print();
-            //Trace.WriteLine("#### After rethreading");
-
+            RBTree bst = new();
+            List<int> levelSIDs = new List<int>();
+            LoadChildren(bst, entry.Child, levelSIDs);
             return bst;
-        }
-
-        private RBTree DoLoadChildrenTrusted(IDirectoryEntry de)
-        {
-            RBTree bst = null;
-
-            if (de.Child != DirectoryEntry.NOSTREAM)
-            {
-                bst = new RBTree(directoryEntries[de.Child]);
-            }
-
-            return bst;
-        }
-
-        private void LoadChildren(RBTree bst, IDirectoryEntry de)
-        {
-            if (de.Child != DirectoryEntry.NOSTREAM)
-            {
-                IDirectoryEntry child = directoryEntries[de.Child];
-                if (child.StgType != StgType.StgInvalid)
-                {
-                    List<int> levelSIDs = new List<int>();
-                    LoadChildren(bst, child, levelSIDs);
-                }
-            }
         }
 
         private static void NullifyChildNodes(IDirectoryEntry de)


### PR DESCRIPTION
Ensure both the root and left sibilings are considered when checking for duplicate SIDs.

Also, remove redundant lookups.