### PR TITLE
Add a helper function to add user defined properties to the user defined properties container.

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/OLEPropertiesContainer.cs
@@ -180,11 +180,16 @@ namespace OpenMcdf.Extensions.OLEProperties
         /// </summary>
         /// <param name="vtPropertyType">The type of property to create.</param>
         /// <param name="name">The name of the new property.</param>
-        /// <returns>The new property, of null if this container can't contain user defined properties.</returns>
+        /// <returns>The new property.</returns>
+        /// <exception cref="InvalidOperationException">If UserDefinedProperties aren't allowed for this container.</exception>
+        /// <exception cref="ArgumentException">If a property with the name <paramref name="name"/> already exists."/></exception>
         public OLEProperty AddUserDefinedProperty(VTPropertyType vtPropertyType, string name)
         {
+            // @@TBD@@ If this is a DocumentSummaryInfo container, we could forward the add on to that.
             if (this.ContainerType != ContainerType.UserDefinedProperties)
-                return null;
+            {
+                throw new InvalidOperationException($"UserDefinedProperties are not allowed in containers of type {this.ContainerType}");
+            }
 
             // As per https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-OLEPS/4177a4bc-5547-49fe-a4d9-4767350fd9cf
             // the property names have to be unique, and are case insensitive.
@@ -192,7 +197,7 @@ namespace OpenMcdf.Extensions.OLEProperties
             {
                 throw new ArgumentException($"User defined property names must be unique and {name} already exists", nameof(name));
             }
-    
+
             // Work out a property identifier - must be > 1 and unique as per 
             // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleps/333959a3-a999-4eca-8627-48a224e63e77
             uint identifier = 2;


### PR DESCRIPTION
Refs comments in https://github.com/ironfede/openmcdf/issues/104 - I think it'd be useful to have a built in function that handles the management of property identifiers and names so that users don't have to do it manually.

Question: The names of user defined properties are required to be unique within a file so it needs some validation.
Should an attempt to add a user defined property with a name that already exists be an error (e.g. throw an exception), or should it replace any existing property with a new one (it might have to handle the new property having a different type than the existing one, which would need to remove the existing property and create a new one)