### PR TITLE
Correct the parameters to ArgumentException in StreamDecorator.Seek

### DIFF
--- a/sources/OpenMcdf.Extensions/StreamDecorator.cs
+++ b/sources/OpenMcdf.Extensions/StreamDecorator.cs
@@ -94,7 +94,7 @@ namespace OpenMcdf.Extensions
                     break;
 
                 default:
-                    throw new ArgumentException(nameof(origin), "Invalid seek origin");
+                    throw new ArgumentException("Invalid seek origin", nameof(origin));
             }
 
             if (position > Length)


### PR DESCRIPTION
Visual Studio points out that the parameter name is the second parameter to ArgumentException

![image](https://github.com/user-attachments/assets/3af6f9b4-795b-4b63-ae62-626530d3690b)
