### PR TITLE
Is StreamView::freeSectors needed?

### DIFF
--- a/sources/OpenMcdf/StreamView.cs
+++ b/sources/OpenMcdf/StreamView.cs
@@ -22,8 +22,6 @@ namespace OpenMcdf
         private long position;
         private readonly Stream stream;
         private readonly bool isFatStream;
-        private readonly List<Sector> freeSectors = new();
-        public IEnumerable<Sector> FreeSectors => freeSectors;
 
         public StreamView(List<Sector> sectorChain, int sectorSize, Stream stream)
         {


### PR DESCRIPTION
I tried running the code through the whole solution code analysis in Rider and it determined that 'freeSectors' isn't mutated after creation, so I wonder if it's needed? (StreamView is an internal class, so if there are internal users then there shouldn't be any users at all).

As an extra test, I tried running a benchmark against the current code and with freeSectors removed and got

before:
```
| Method                  | Job      | Runtime  | Mean      | Error     | StdDev     | Median    | Gen0     | Gen1    | Allocated |
|------------------------ |--------- |--------- |----------:|----------:|-----------:|----------:|---------:|--------:|----------:|
| CreateCompoundDocument  | .NET 6.0 | .NET 6.0 |  50.47 us |  1.820 us |   5.251 us |  48.50 us |   6.8359 |  0.1221 |  42.19 KB |
| ReadDocFile             | .NET 6.0 | .NET 6.0 | 648.27 us | 12.958 us |  34.362 us | 645.34 us | 162.1094 | 24.4141 | 995.83 KB |
| ReadOnePropFromADocFile | .NET 6.0 | .NET 6.0 | 633.38 us | 12.618 us |  23.701 us | 631.44 us | 162.1094 | 25.3906 | 993.42 KB |
| CreateCompoundDocument  | .NET 8.0 | .NET 8.0 |  42.88 us |  0.931 us |   2.672 us |  43.08 us |   6.8359 |  0.1221 |   42.2 KB |
| ReadDocFile             | .NET 8.0 | .NET 8.0 | 599.77 us | 12.722 us |  37.311 us | 599.49 us | 160.1563 | 27.3438 | 995.86 KB |
| ReadOnePropFromADocFile | .NET 8.0 | .NET 8.0 | 527.57 us | 36.255 us | 103.437 us | 493.24 us | 162.1094 | 27.3438 | 993.44 KB |
```

after
```
| Method                  | Job      | Runtime  | Mean      | Error     | StdDev    | Median    | Gen0     | Gen1    | Allocated |
|------------------------ |--------- |--------- |----------:|----------:|----------:|----------:|---------:|--------:|----------:|
| CreateCompoundDocument  | .NET 6.0 | .NET 6.0 |  39.58 us |  0.635 us |  0.563 us |  39.57 us |   6.8359 |  0.1221 |  42.11 KB |
| ReadDocFile             | .NET 6.0 | .NET 6.0 | 512.33 us | 10.039 us | 15.630 us | 507.56 us | 156.2500 | 25.3906 | 957.85 KB |
| ReadOnePropFromADocFile | .NET 6.0 | .NET 6.0 | 528.27 us |  9.799 us | 19.794 us | 522.99 us | 155.2734 | 24.4141 | 955.42 KB |
| CreateCompoundDocument  | .NET 8.0 | .NET 8.0 |  39.19 us |  1.562 us |  4.455 us |  37.36 us |   6.8359 |  0.1221 |  42.12 KB |
| ReadDocFile             | .NET 8.0 | .NET 8.0 | 441.14 us |  8.335 us |  9.922 us | 440.31 us | 156.2500 | 30.2734 | 957.86 KB |
| ReadOnePropFromADocFile | .NET 8.0 | .NET 8.0 | 455.55 us |  9.087 us | 17.068 us | 449.14 us | 154.2969 | 25.3906 | 955.47 KB |
```
which seems a pretty substantial change in memory allocations.