### PR TITLE
Plug VT_I8_Property into PropertyFactory

### DIFF
--- a/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
+++ b/sources/OpenMcdf.Extensions/OLEProperties/PropertyFactory.cs
@@ -30,6 +30,7 @@ namespace OpenMcdf.Extensions.OLEProperties
                 VTPropertyType.VT_UI1 => new VT_UI1_Property(vType, isVariant),
                 VTPropertyType.VT_UI2 => new VT_UI2_Property(vType, isVariant),
                 VTPropertyType.VT_UI4 => new VT_UI4_Property(vType, isVariant),
+                VTPropertyType.VT_I8 => new VT_I8_Property(vType, isVariant),
                 VTPropertyType.VT_UI8 => new VT_UI8_Property(vType, isVariant),
                 VTPropertyType.VT_BSTR => new VT_LPSTR_Property(vType, codePage, isVariant),
                 VTPropertyType.VT_LPSTR => CreateLpstrProperty(vType, codePage, propertyIdentifier, isVariant),


### PR DESCRIPTION
The code analysis in Rider pointed out that VT_I8_Property was never used, but as VT_I8 is listed as a permitted property type in https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleps/2a4589eb-9a23-4a8b-adbd-3e368233c099 I think it should be plugged in?