### PR TITLE
Set ContinuousIntegrationBuild to true in CI builds

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,6 @@ jobs:
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application
-      run: dotnet build -c $env:Configuration
+      run: dotnet build -c $env:Configuration /p:ContinuousIntegrationBuild=true
       env:
         Configuration: ${{ matrix.configuration }}


### PR DESCRIPTION
Idea being to enable deterministic build in the CI (so it gets deterministic paths in the debug symbols and such.