### PR TITLE
Make sure PropertyNames is always populated in AddUserDefinedProperty()

### DIFF
--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -140,6 +140,8 @@ public class OlePropertiesContainer
         if (this.ContainerType != ContainerType.UserDefinedProperties)
             throw new InvalidOperationException();
 
+        PropertyNames ??= new();
+
         // As per https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-OLEPS/4177a4bc-5547-49fe-a4d9-4767350fd9cf
         // the property names have to be unique, and are case insensitive.
         if (PropertyNames.Any(property => property.Value.Equals(name, StringComparison.InvariantCultureIgnoreCase)))


### PR DESCRIPTION
The way the code was set up *should* mean that PropertyNames is never null in UserDefinedProperties containers, so it should never be null when it gets to the ```PropertyNames.Any```. However, the compiler can't tell that, so you get nullability warnings in the build

It might be safe to ```!``` the references here, but then - I don't think there should be any problem with just creating PropertyNames here so maybe that's the safer approach to take.