### PR TITLE
Rework the handling of FMTID0 in OlePropertiesContainer

### DIFF
--- a/OpenMcdf.Ole.Tests/OlePropertiesExtensionsTests.cs
+++ b/OpenMcdf.Ole.Tests/OlePropertiesExtensionsTests.cs
@@ -510,11 +510,15 @@ public class OlePropertiesExtensionsTests
             [4] = "Project Name"
         };
 
+        Guid expectedFmtid0 = Guid.Parse("f0d6d0b1-a0d8-11ce-8aa2-08003601e988");
+
         using (var cf = RootStorage.Open(modifiedStream, StorageModeFlags.LeaveOpen))
         {
             using CfbStream testStream = cf.OpenStream("Issue134");
             OlePropertiesContainer co = new(testStream);
 
+            Assert.AreEqual(ContainerType.AppSpecific, co.ContainerType);
+            Assert.AreEqual(expectedFmtid0, co.FMTID0);
             CollectionAssert.AreEqual(expectedPropertyNames, co.PropertyNames);
 
             // Write test file
@@ -527,6 +531,8 @@ public class OlePropertiesExtensionsTests
             using CfbStream testStream = cf.OpenStream("Issue134");
             OlePropertiesContainer co = new(testStream);
 
+            Assert.AreEqual(ContainerType.AppSpecific, co.ContainerType);
+            Assert.AreEqual(expectedFmtid0, co.FMTID0);
             CollectionAssert.AreEqual(expectedPropertyNames, co.PropertyNames);
         }
     }


### PR DESCRIPTION
As #142 but against v3.0 and with an extension to one of the unit tests to test that it retains the fmtid for a file with an 'app specific' (i.e not a known value) value,