### PR TITLE
Simplify null terminator handling in DictionaryProperty.Write

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -104,36 +104,23 @@ public sealed class DictionaryProperty : IProperty
         // In either case, the string must be null terminated
         if (codePage == CodePages.WinUnicode)
         {
-            bool addNullTerminator =
-                byteLength == 0 || nameBytes[byteLength - 1] != '\0' || nameBytes[byteLength - 2] != '\0';
-
-            if (addNullTerminator)
-                byteLength += 2;
+            // Two bytes padding for Unicode strings
+            byteLength += 2;
 
             bw.Write(byteLength / 2);
             bw.Write(nameBytes);
-
-            if (addNullTerminator)
-            {
-                bw.Write((byte)0);
-                bw.Write((byte)0);
-            }
+            bw.Write((byte)0);
+            bw.Write((byte)0);
 
             WritePaddingIfNeeded(bw, (int)byteLength);
         }
         else
         {
-            bool addNullTerminator =
-                byteLength == 0 || nameBytes[byteLength - 1] != '\0';
-
-            if (addNullTerminator)
-                byteLength += 1;
+            byteLength += 1;
 
             bw.Write(byteLength);
             bw.Write(nameBytes);
-
-            if (addNullTerminator)
-                bw.Write((byte)0);
+            bw.Write((byte)0);
         }
     }
 


### PR DESCRIPTION
I believe this isn't needed after #124, where the read side was changes to remove all the null terminators, and the write side of various other string properties was changed to always write null terminators