### PR TITLE
Make PropertyIdentifierAndOffset internal

### DIFF
--- a/OpenMcdf.Ole/PropertyIdentifierAndOffset.cs
+++ b/OpenMcdf.Ole/PropertyIdentifierAndOffset.cs
@@ -1,6 +1,6 @@
 ﻿namespace OpenMcdf.Ole;
 
-public class PropertyIdentifierAndOffset : IBinarySerializable
+internal sealed class PropertyIdentifierAndOffset : IBinarySerializable
 {
     public uint PropertyIdentifier { get; set; }
     public uint Offset { get; set; }


### PR DESCRIPTION
I think it should be treated as an implementation detail of the (already internal) PropertySet/PropertySetStream