### PR TITLE
Fix parameter order for ArgumentException

### DIFF
--- a/OpenMcdf/FatStream.cs
+++ b/OpenMcdf/FatStream.cs
@@ -139,7 +139,7 @@ internal class FatStream : Stream
                 break;
 
             default:
-                throw new ArgumentException(nameof(origin), "Invalid seek origin");
+                throw new ArgumentException("Invalid seek origin", nameof(origin));
         }
 
         return position;

--- a/OpenMcdf/MiniFatStream.cs
+++ b/OpenMcdf/MiniFatStream.cs
@@ -129,7 +129,7 @@ internal sealed class MiniFatStream : Stream
                 break;
 
             default:
-                throw new ArgumentException(nameof(origin), "Invalid seek origin.");
+                throw new ArgumentException("Invalid seek origin.", nameof(origin));
         }
 
         return position;


### PR DESCRIPTION
I thought this had already been done :-(