### PR TITLE
Read data for PropertyIdentifierAndOffset using the Read() member fun…

### DIFF
--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -58,11 +58,8 @@ internal sealed class PropertySetStream
         // Read property offsets (P0)
         for (int i = 0; i < propertyCount; i++)
         {
-            PropertyIdentifierAndOffset pio = new()
-            {
-                PropertyIdentifier = br.ReadUInt32(),
-                Offset = br.ReadUInt32()
-            };
+            PropertyIdentifierAndOffset pio = new();
+            pio.Read(br);
             PropertySet0.PropertyIdentifierAndOffsets.Add(pio);
         }
 
@@ -92,11 +89,8 @@ internal sealed class PropertySetStream
             // Read property offsets
             for (int i = 0; i < propertyCount; i++)
             {
-                PropertyIdentifierAndOffset pio = new()
-                {
-                    PropertyIdentifier = br.ReadUInt32(),
-                    Offset = br.ReadUInt32()
-                };
+                PropertyIdentifierAndOffset pio = new();
+                pio.Read(br);
                 PropertySet1.PropertyIdentifierAndOffsets.Add(pio);
             }
 


### PR DESCRIPTION
…ction

Just a thought - the code coverage report shows the Read() function as uncalled currently (the Write function is used for writes, so this is maybe a bit more consistent to use the member functions for both)