### PR TITLE
Make IBinarySerializable internal

### DIFF
--- a/OpenMcdf.Ole/IBinarySerializable.cs
+++ b/OpenMcdf.Ole/IBinarySerializable.cs
@@ -1,6 +1,6 @@
 ﻿namespace OpenMcdf.Ole;
 
-public interface IBinarySerializable
+internal interface IBinarySerializable
 {
     void Write(BinaryWriter bw);
     void Read(BinaryReader br);


### PR DESCRIPTION
The previous visibiity changes should have made all usages internal