### PR TITLE
Seal PropertyContext

### DIFF
--- a/OpenMcdf.Ole/PropertyContext.cs
+++ b/OpenMcdf.Ole/PropertyContext.cs
@@ -6,7 +6,7 @@ public enum Behavior
     CaseInsensitive
 }
 
-public class PropertyContext
+public sealed class PropertyContext
 {
     public int CodePage { get; set; }
     public Behavior Behavior { get; set; }


### PR DESCRIPTION
I don't think there is a need for this to be subclassable - it's part of the public API of OlePropertiesContainer but instances are created internally and the property is read only, so it can't be replaced with a different class by users.