### PR TITLE
Read the PropertySet Locale property into the PropertyContext

### DIFF
--- a/OpenMcdf.Ole.Tests/OlePropertiesExtensionsTests.cs
+++ b/OpenMcdf.Ole.Tests/OlePropertiesExtensionsTests.cs
@@ -519,6 +519,7 @@ public class OlePropertiesExtensionsTests
 
             Assert.AreEqual(ContainerType.AppSpecific, co.ContainerType);
             Assert.AreEqual(expectedFmtid0, co.FMTID0);
+            Assert.AreEqual(1040u, co.Context.Locale);
             CollectionAssert.AreEqual(expectedPropertyNames, co.PropertyNames);
 
             // Write test file

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -65,7 +65,8 @@ public class OlePropertiesContainer
 
         Context = new PropertyContext()
         {
-            CodePage = pStream.PropertySet0.PropertyContext.CodePage
+            CodePage = pStream.PropertySet0.PropertyContext.CodePage,
+            Locale = pStream.PropertySet0.PropertyContext.Locale
         };
 
         for (int i = 0; i < pStream.PropertySet0.Properties.Count; i++)

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -13,12 +13,26 @@ internal sealed class PropertySet
     public void LoadContext(int propertySetOffset, BinaryReader br)
     {
         long currPos = br.BaseStream.Position;
+
+        // Read the code page - this should always be present
         int codePageOffset = (int)(propertySetOffset + PropertyIdentifierAndOffsets.First(pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.CodePage).Offset);
         br.BaseStream.Seek(codePageOffset, SeekOrigin.Begin);
 
         var vType = (VTPropertyType)br.ReadUInt16();
         br.ReadUInt16(); // Ushort Padding
         PropertyContext.CodePage = (ushort)br.ReadInt16();
+
+        // Read the Locale, if present
+        PropertyIdentifierAndOffset? localeProperty = PropertyIdentifierAndOffsets.FirstOrDefault(pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.Locale);
+        if (localeProperty is not null)
+        {
+            long localeOffset = (propertySetOffset + localeProperty.Offset);
+            br.BaseStream.Seek(localeOffset, SeekOrigin.Begin);
+
+            vType = (VTPropertyType)br.ReadUInt16();
+            br.ReadUInt16(); // Ushort Padding
+            PropertyContext.Locale = br.ReadUInt32();
+        }
 
         br.BaseStream.Position = currPos;
     }


### PR DESCRIPTION
…property is present in the file

As long as PropertyContext has a Locale property, I think it should be populated where possible, and as it happens the existing 'Issue134' test file contains a Locale property that can be used for testing.

A thought whilst looking though - the Microsoft docs at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleps/bb452c07-79f7-46e0-bfb7-122c347cc5c8 state that Locale is an optional property, so I wonder if the PropertyContext.Locale property should be nullable rather than being 0 if there is no locale specified?