### PR TITLE
Added FileShare parameters to RootStorage.Open() to allow reading files used in other processes.

### DIFF
--- a/OpenMcdf.Tests/StorageTests.cs
+++ b/OpenMcdf.Tests/StorageTests.cs
@@ -309,4 +309,19 @@ public sealed class StorageTests
             Assert.AreEqual(1U, storage.StateBits);
         }
     }
+
+    [TestMethod]
+    [DataRow("MultipleStorage.cfs")]
+    public void OpenReadOnlyWithSharing(string fileName)
+    {
+        using (var rootStorage = RootStorage.Open(fileName, FileMode.Open, FileAccess.ReadWrite, share: FileShare.ReadWrite))
+        {
+            Assert.IsTrue(rootStorage.ContainsEntry("MyStorage"));
+
+            using (var rootStorage2 = RootStorage.OpenRead(fileName, share: FileShare.ReadWrite))
+            {
+                Assert.IsTrue(rootStorage2.ContainsEntry("MyStorage"));
+            }
+        }
+    }
 }

--- a/OpenMcdf/RootStorage.cs
+++ b/OpenMcdf/RootStorage.cs
@@ -92,7 +92,8 @@ public sealed class RootStorage : Storage, IDisposable
         return Open(stream, flags);
     }
 
-    public static RootStorage Open(string fileName, FileMode mode, FileAccess access, StorageModeFlags flags = StorageModeFlags.None)
+    public static RootStorage Open(string fileName, FileMode mode, FileAccess access, FileShare share = FileShare.ReadWrite,
+                                   StorageModeFlags flags = StorageModeFlags.None)
     {
         if (fileName is null)
             throw new ArgumentNullException(nameof(fileName));
@@ -101,7 +102,7 @@ public sealed class RootStorage : Storage, IDisposable
         ThrowIfInvalid(access);
         ThrowIfLeaveOpen(flags);
 
-        FileStream stream = File.Open(fileName, mode, access);
+        FileStream stream = File.Open(fileName, mode, access, share);
         return Open(stream, flags);
     }
 
@@ -119,14 +120,14 @@ public sealed class RootStorage : Storage, IDisposable
         return new RootStorage(rootContextSite, flags);
     }
 
-    public static RootStorage OpenRead(string fileName, StorageModeFlags flags = StorageModeFlags.None)
+    public static RootStorage OpenRead(string fileName, FileShare share = FileShare.ReadWrite, StorageModeFlags flags = StorageModeFlags.None)
     {
         if (fileName is null)
             throw new ArgumentNullException(nameof(fileName));
 
         ThrowIfLeaveOpen(flags);
 
-        FileStream stream = File.OpenRead(fileName);
+        FileStream stream = File.Open(fileName, FileMode.Open, FileAccess.Read, share);
         return Open(stream, flags);
     }
 


### PR DESCRIPTION
Fix for issue #260.

Added optional FileShare parameter to RootStorage.Read methods
Added test for reading files used in other processes