### PR TITLE
Use the stream PropertyContext when constructing an OlePropertiesContainer

### DIFF
--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -63,11 +63,7 @@ public class OlePropertiesContainer
         PropertyNames = (Dictionary<uint, string>?)pStream.PropertySet0!.Properties
             .FirstOrDefault(p => p.PropertyType == PropertyType.DictionaryProperty)?.Value;
 
-        Context = new PropertyContext()
-        {
-            CodePage = pStream.PropertySet0.PropertyContext.CodePage,
-            Locale = pStream.PropertySet0.PropertyContext.Locale
-        };
+        Context = pStream.PropertySet0.PropertyContext;
 
         for (int i = 0; i < pStream.PropertySet0.Properties.Count; i++)
         {


### PR DESCRIPTION
…from the PropertySetStream directly instead of cloning it.

As suggested in comments in https://github.com/ironfede/openmcdf/pull/259