### PR TITLE
Enhanced StructuredStorageExplorer Display

### DIFF
--- a/StructuredStorageExplorer/MainForm.cs
+++ b/StructuredStorageExplorer/MainForm.cs
@@ -125,7 +125,7 @@ public partial class MainForm : Form
 
         if (cf is not null)
         {
-            TreeNode root = treeView1.Nodes.Add(cf.EntryInfo.Name);
+            TreeNode root = treeView1.Nodes.Add(cf.EntryInfo.Name.WithEscaped());
             root.ImageIndex = 0;
             root.Tag = new NodeSelection(null, cf.EntryInfo);
 
@@ -167,7 +167,7 @@ public partial class MainForm : Form
     {
         foreach (EntryInfo item in storage.EnumerateEntries())
         {
-            TreeNode childNode = node.Nodes.Add(item.Name);
+            TreeNode childNode = node.Nodes.Add(item.Name.WithEscaped());
             childNode.Tag = new NodeSelection(storage, item);
 
             if (item.Type is EntryType.Storage)
@@ -371,7 +371,7 @@ public partial class MainForm : Form
                 hexEditor.ByteProvider = null;
             }
 
-            propertyGrid1.SelectedObject = nodeSelection.EntryInfo;
+            propertyGrid1.SelectedObject = nodeSelection.EntryInfo.WithEscaped();
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or FileFormatException)
         {

--- a/StructuredStorageExplorer/StructuredStorageExplorer.csproj
+++ b/StructuredStorageExplorer/StructuredStorageExplorer.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Be.Windows.Forms.HexBox.Net5" />

--- a/StructuredStorageExplorer/Utils.cs
+++ b/StructuredStorageExplorer/Utils.cs
@@ -1,4 +1,6 @@
-﻿namespace StructuredStorageExplorer;
+﻿using OpenMcdf;
+
+namespace StructuredStorageExplorer;
 
 static class Utils
 {
@@ -42,5 +44,23 @@ static class Utils
         DialogResult dialogResult = form.ShowDialog();
         value = textBox.Text;
         return dialogResult;
+    }
+
+    public static EntryInfo WithEscaped(this EntryInfo entry) => entry with { Name = EscapedControl(entry.Name), Path = EscapedControl(entry.Path) };
+
+    public static string WithEscaped(this string entry) => EscapedControl(entry);
+
+    private static string EscapedControl(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        var sb = new System.Text.StringBuilder();
+        foreach (char c in s)
+        {
+            if (char.IsControl(c))
+                sb.Append($"\\u{((int)c):x4}");
+            else
+                sb.Append(c);
+        }
+        return sb.ToString();
     }
 }

--- a/StructuredStorageExplorer/app.manifest
+++ b/StructuredStorageExplorer/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+		<security>
+			<requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+				<!-- UAC 清单选项
+             如果想要更改 Windows 用户帐户控制级别，请使用
+             以下节点之一替换 requestedExecutionLevel 节点。
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            指定 requestedExecutionLevel 元素将禁用文件和注册表虚拟化。
+            如果你的应用程序需要此虚拟化来实现向后兼容性，则移除此
+            元素。
+        -->
+				<requestedExecutionLevel level="asInvoker" uiAccess="false" />
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!-- 设计此应用程序与其一起工作且已针对此应用程序进行测试的
+           Windows 版本的列表。取消评论适当的元素，
+           Windows 将自动选择最兼容的环境。 -->
+
+			<!-- Windows Vista -->
+			<!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+			<!-- Windows 7 -->
+			<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+			<!-- Windows 8 -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+			<!-- Windows 8.1 -->
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+			<!-- Windows 10 -->
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+		</application>
+	</compatibility>
+
+	<!-- 指示该应用程序可感知 DPI 且 Windows 在 DPI 较高时将不会对其进行
+       自动缩放。Windows Presentation Foundation (WPF)应用程序自动感知 DPI，无需
+       选择加入。选择加入此设置的 Windows 窗体应用程序(面向 .NET Framework 4.6)还应
+       在其 app.config 中将 "EnableWindowsFormsHighDpiAutoResizing" 设置设置为 "true"。
+       
+       将应用程序设为感知长路径。请参阅 https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+		</windowsSettings>
+	</application>
+
+
+	<!-- 启用 Windows 公共控件和对话框的主题(Windows XP 和更高版本) -->
+
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*"
+        />
+		</dependentAssembly>
+	</dependency>
+
+
+</assembly>

--- a/StructuredStorageExplorer/app.manifest
+++ b/StructuredStorageExplorer/app.manifest
@@ -4,76 +4,33 @@
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>
 			<requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-				<!-- UAC 清单选项
-             如果想要更改 Windows 用户帐户控制级别，请使用
-             以下节点之一替换 requestedExecutionLevel 节点。
-
-        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
-        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
-        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
-
-            指定 requestedExecutionLevel 元素将禁用文件和注册表虚拟化。
-            如果你的应用程序需要此虚拟化来实现向后兼容性，则移除此
-            元素。
-        -->
 				<requestedExecutionLevel level="asInvoker" uiAccess="false" />
 			</requestedPrivileges>
 		</security>
 	</trustInfo>
-
 	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
 		<application>
-			<!-- 设计此应用程序与其一起工作且已针对此应用程序进行测试的
-           Windows 版本的列表。取消评论适当的元素，
-           Windows 将自动选择最兼容的环境。 -->
-
 			<!-- Windows Vista -->
 			<!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
-
 			<!-- Windows 7 -->
 			<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
 			<!-- Windows 8 -->
 			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
-
 			<!-- Windows 8.1 -->
 			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
-
 			<!-- Windows 10 -->
 			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
-
 		</application>
 	</compatibility>
-
-	<!-- 指示该应用程序可感知 DPI 且 Windows 在 DPI 较高时将不会对其进行
-       自动缩放。Windows Presentation Foundation (WPF)应用程序自动感知 DPI，无需
-       选择加入。选择加入此设置的 Windows 窗体应用程序(面向 .NET Framework 4.6)还应
-       在其 app.config 中将 "EnableWindowsFormsHighDpiAutoResizing" 设置设置为 "true"。
-       
-       将应用程序设为感知长路径。请参阅 https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-
 	<application xmlns="urn:schemas-microsoft-com:asm.v3">
 		<windowsSettings>
 			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
 			<longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
 		</windowsSettings>
 	</application>
-
-
-	<!-- 启用 Windows 公共控件和对话框的主题(Windows XP 和更高版本) -->
-
 	<dependency>
 		<dependentAssembly>
-			<assemblyIdentity
-				type="win32"
-				name="Microsoft.Windows.Common-Controls"
-				version="6.0.0.0"
-				processorArchitecture="*"
-				publicKeyToken="6595b64144ccf1df"
-				language="*"
-        />
+			<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
 		</dependentAssembly>
 	</dependency>
-
-
 </assembly>


### PR DESCRIPTION
1. Supports displaying special control characters in **StructuredStorageExplorer**. When view the office files encrypted by RMS, there will be control characters such as `\u0006` `\u0009`. Reference [2.1.7.3 Data Spaces Storage (\006DataSpaces)](https://learn.microsoft.com/zh-cn/openspecs/office_file_formats/ms-xls/2d2a5085-fa01-4807-b232-f39878b399ce)
2. Support dpiAware