### PR TITLE
Remove unsed IndexRange PacakgeReference

### DIFF
--- a/OpenMcdf/OpenMcdf.csproj
+++ b/OpenMcdf/OpenMcdf.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="IndexRange" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Memory" />
   </ItemGroup>


### PR DESCRIPTION
I'd been looking at this wondering if it's be possible to use PolySharp as a dependency free polyfill for the index/range stuff and the local definitions of both IsExternalInit and the various nullability attributes, but then I noticed that it still builds and passes the tests when the package is just removed.

Also, ILSpy doesn't show any dependency on it in the published dll:

![image](https://github.com/user-attachments/assets/60985158-ac70-450a-a6bc-133f7c873eaf)

So - is it still needed?