### PR TITLE
Mark "sealed" and "static" where appropriate

### DIFF
--- a/OpenMcdf.Tests/StreamTests.cs
+++ b/OpenMcdf.Tests/StreamTests.cs
@@ -342,7 +342,7 @@ public sealed class StreamTests
     public void ModifyCommitSingleByte(Version version, int length) => ModifyCommit(version, length, WriteMode.SingleByte);
 #endif
 
-    void ModifyCommit(Version version, int length, WriteMode writeMode)
+    static void ModifyCommit(Version version, int length, WriteMode writeMode)
     {
         // Fill with bytes equal to their position modulo 256
         byte[] expectedBuffer = TestData.CreateByteArray(length);

--- a/OpenMcdf/DifatSectorEnumerator.cs
+++ b/OpenMcdf/DifatSectorEnumerator.cs
@@ -5,7 +5,7 @@ namespace OpenMcdf;
 /// <summary>
 /// Enumerates the <see cref="Sector"/>s in a DIFAT chain.
 /// </summary>
-internal class DifatSectorEnumerator : ContextBase, IEnumerator<Sector>
+internal sealed class DifatSectorEnumerator : ContextBase, IEnumerator<Sector>
 {
     bool start = true;
     uint index = uint.MaxValue;

--- a/OpenMcdf/DirectoryEntryComparer.cs
+++ b/OpenMcdf/DirectoryEntryComparer.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Provides a <see cref="IComparer{T}"/> for <see cref="DirectoryEntry"/> objects.
 /// </summary>
-internal class DirectoryEntryComparer : IComparer<DirectoryEntry>
+internal sealed class DirectoryEntryComparer : IComparer<DirectoryEntry>
 {
     public static DirectoryEntryComparer Default { get; } = new();
 

--- a/OpenMcdf/FatEnumerator.cs
+++ b/OpenMcdf/FatEnumerator.cs
@@ -6,7 +6,7 @@ namespace OpenMcdf;
 /// <summary>
 /// Enumerates the <see cref="FatEntry"/> records in a <see cref="Fat"/>.
 /// </summary>
-internal class FatEnumerator : IEnumerator<FatEntry>
+internal sealed class FatEnumerator : IEnumerator<FatEntry>
 {
     readonly Fat fat;
     bool start = true;

--- a/OpenMcdf/FatStream.cs
+++ b/OpenMcdf/FatStream.cs
@@ -5,7 +5,7 @@ namespace OpenMcdf;
 /// <summary>
 /// Provides a <inheritdoc cref="Stream"/> for a stream object in a compound file./>.
 /// </summary>
-internal class FatStream : Stream
+internal sealed class FatStream : Stream
 {
     readonly RootContextSite rootContextSite;
     readonly FatChainEnumerator chain;

--- a/OpenMcdf/RootContextSite.cs
+++ b/OpenMcdf/RootContextSite.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A site for the <see cref="RootContext"/> object, to allow switching streams.
 /// </summary>
-internal class RootContextSite
+internal sealed class RootContextSite
 {
     RootContext? context;
 

--- a/OpenMcdf/System/CompilerServices.cs
+++ b/OpenMcdf/System/CompilerServices.cs
@@ -1,5 +1,5 @@
 ﻿namespace System.Runtime.CompilerServices;
 
-internal class IsExternalInit
+internal static class IsExternalInit
 {
 }

--- a/OpenMcdf/TransactedStream.cs
+++ b/OpenMcdf/TransactedStream.cs
@@ -5,7 +5,7 @@ namespace OpenMcdf;
 /// <summary>
 /// Stores modifications to a CFB stream that can be committed or reverted.
 /// </summary>
-internal class TransactedStream : Stream
+internal sealed class TransactedStream : Stream
 {
     readonly RootContextSite rootContextSite;
     readonly Stream originalStream;


### PR DESCRIPTION
This improves code readability and performance.