### PR TITLE
Fix SeekOrigin.End behavior

### DIFF
--- a/OpenMcdf.Tests/StreamTests.cs
+++ b/OpenMcdf.Tests/StreamTests.cs
@@ -118,10 +118,16 @@ public sealed class StreamTests
         using var rootStorage = RootStorage.OpenRead(fileName);
         using Stream stream = rootStorage.OpenStream("TestStream");
 
-        stream.Seek(0, SeekOrigin.Begin);
+        Assert.AreEqual(0, stream.Seek(0, SeekOrigin.Begin));
+        Assert.AreEqual(0, stream.Seek(0, SeekOrigin.Current));
+        Assert.AreEqual(length, stream.Seek(0, SeekOrigin.End));
+
+        stream.Position = 0;
+
         Assert.ThrowsExactly<IOException>(() => stream.Seek(-1, SeekOrigin.Begin));
         Assert.ThrowsExactly<IOException>(() => stream.Seek(-1, SeekOrigin.Current));
-        Assert.ThrowsExactly<IOException>(() => stream.Seek(length + 1, SeekOrigin.End));
+        Assert.ThrowsExactly<IOException>(() => stream.Seek(-1 - length, SeekOrigin.End));
+
         Assert.ThrowsExactly<ArgumentException>(() => stream.Seek(length, (SeekOrigin)3));
     }
 

--- a/OpenMcdf/FatStream.cs
+++ b/OpenMcdf/FatStream.cs
@@ -134,9 +134,9 @@ internal sealed class FatStream : Stream
                 break;
 
             case SeekOrigin.End:
-                if (Length - offset < 0)
+                if (Length + offset < 0)
                     ThrowHelper.ThrowSeekBeforeOrigin();
-                position = Length - offset;
+                position = Length + offset;
                 break;
 
             default:

--- a/OpenMcdf/MiniFatStream.cs
+++ b/OpenMcdf/MiniFatStream.cs
@@ -123,9 +123,9 @@ internal sealed class MiniFatStream : Stream
                 break;
 
             case SeekOrigin.End:
-                if (Length - offset < 0)
+                if (Length + offset < 0)
                     ThrowHelper.ThrowSeekBeforeOrigin();
-                position = Length - offset;
+                position = Length + offset;
                 break;
 
             default:


### PR DESCRIPTION
Offsets before the end of a stream are conventionally negative.