### PR TITLE
Clear removed directory entries

### DIFF
--- a/OpenMcdf/DirectoryEntries.cs
+++ b/OpenMcdf/DirectoryEntries.cs
@@ -121,7 +121,7 @@ internal sealed class DirectoryEntries : ContextBase, IDisposable
         while (directoryEntryEnumerator.MoveNext())
         {
             DirectoryEntry current = directoryEntryEnumerator.Current;
-            if (directoryEntryEnumerator.Current.Type is StorageType.Unallocated)
+            if (current.Type is StorageType.Unallocated)
                 return current;
         }
 

--- a/OpenMcdf/DirectoryTree.cs
+++ b/OpenMcdf/DirectoryTree.cs
@@ -186,6 +186,9 @@ internal sealed class DirectoryTree
                 directories.Write(newRightChildParent);
             }
         }
+
+        entry.Recycle();
+        directories.Write(entry);
     }
 
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION
Directory entries were removed from the directory tree, but were not cleared from directory entries FAT chain, so were not freed until consolidated.