### PR TITLE
Improve switching to and from mini FAT stream

### DIFF
--- a/OpenMcdf/CfbStream.cs
+++ b/OpenMcdf/CfbStream.cs
@@ -108,32 +108,12 @@ public sealed class CfbStream : Stream
 
         if (value >= Header.MiniStreamCutoffSize && stream is MiniFatStream miniStream)
         {
-            long position = miniStream.Position;
-            miniStream.Position = 0;
-
-            DirectoryEntry newDirectoryEntry = directoryEntry.Clone();
-            FatStream fatStream = new(rootContextSite, newDirectoryEntry);
-            fatStream.SetLength(value); // Reserve enough space up front
-            miniStream.CopyTo(fatStream);
-            fatStream.Position = position;
-            stream = fatStream;
-
-            miniStream.SetLength(0);
+            stream = miniStream.SwitchToFatStream(value);
             miniStream.Dispose();
         }
         else if (value < Header.MiniStreamCutoffSize && stream is FatStream fatStream)
         {
-            long position = fatStream.Position;
-            fatStream.Position = 0;
-
-            DirectoryEntry newDirectoryEntry = directoryEntry.Clone();
-            MiniFatStream miniFatStream = new(rootContextSite, newDirectoryEntry);
-            fatStream.SetLength(value); // Truncate the stream
-            fatStream.CopyTo(miniFatStream);
-            miniFatStream.Position = position;
-            stream = miniFatStream;
-
-            fatStream.SetLength(0);
+            stream = fatStream.SwitchToMiniFatStream(value);
             fatStream.Dispose();
         }
         else

--- a/OpenMcdf/FatStream.cs
+++ b/OpenMcdf/FatStream.cs
@@ -10,7 +10,7 @@ internal sealed class FatStream : Stream
     readonly RootContextSite rootContextSite;
     readonly FatChainEnumerator chain;
     long position;
-    bool isDirty;
+    bool isDirectoryEntryDirty;
     bool isDisposed;
 
     private RootContext Context => rootContextSite.Context;
@@ -64,14 +64,53 @@ internal sealed class FatStream : Stream
     {
         this.ThrowIfDisposed(isDisposed);
 
-        if (isDirty)
+        if (isDirectoryEntryDirty)
         {
             Context.DirectoryEntries.Write(DirectoryEntry);
-            isDirty = false;
+            isDirectoryEntryDirty = false;
         }
 
         if (CanWrite)
             Context.Writer.Flush();
+    }
+
+    internal MiniFatStream SwitchToMiniFatStream(long length)
+    {
+        MiniFatStream? miniFatStream = null;
+
+        long originalPosition = Position;
+
+        try
+        {
+            DirectoryEntry newDirectoryEntry = DirectoryEntry.Clone();
+            miniFatStream = new(rootContextSite, newDirectoryEntry);
+            miniFatStream.SetLength(length);
+
+            SetLength(length); // Truncate the stream
+
+            Position = 0;
+            CopyTo(miniFatStream);
+            miniFatStream.Position = originalPosition;
+
+            SetLength(0);
+            isDirectoryEntryDirty = false; // Ownership of the directory entry is transferred to the mini FAT stream.
+
+            return miniFatStream;
+        }
+        catch
+        {
+            try
+            {
+                miniFatStream?.SetLength(0);
+            }
+            finally
+            {
+                Position = originalPosition;
+                miniFatStream?.Dispose();
+            }
+
+            throw;
+        }
     }
 
     uint GetFatChainIndexAndSectorOffset(long offset, out long sectorOffset) => (uint)Math.DivRem(offset, Context.SectorSize, out sectorOffset);
@@ -158,7 +197,7 @@ internal sealed class FatStream : Stream
             DirectoryEntry.StartSectorId = chain.Shrink(requiredChainLength);
 
         DirectoryEntry.StreamLength = value;
-        isDirty = true;
+        isDirectoryEntryDirty = true;
     }
 
     /// <inheritdoc/>
@@ -196,7 +235,7 @@ internal sealed class FatStream : Stream
         if (position > Length)
         {
             DirectoryEntry.StreamLength = position;
-            isDirty = true;
+            isDirectoryEntryDirty = true;
         }
     }
 
@@ -278,7 +317,7 @@ internal sealed class FatStream : Stream
         if (position > Length)
         {
             DirectoryEntry.StreamLength = position;
-            isDirty = true;
+            isDirectoryEntryDirty = true;
         }
     }
 

--- a/OpenMcdf/MiniFatStream.cs
+++ b/OpenMcdf/MiniFatStream.cs
@@ -9,7 +9,7 @@ internal sealed class MiniFatStream : Stream
     readonly MiniFatChainEnumerator miniChain;
     long position;
     bool isDisposed;
-    bool isDirty;
+    bool isDirectoryEntryDirty;
 
     internal MiniFatStream(RootContextSite rootContextSite, DirectoryEntry directoryEntry)
     {
@@ -55,13 +55,50 @@ internal sealed class MiniFatStream : Stream
     {
         this.ThrowIfDisposed(isDisposed);
 
-        if (isDirty)
+        if (isDirectoryEntryDirty)
         {
             Context.DirectoryEntries.Write(DirectoryEntry);
-            isDirty = false;
+            isDirectoryEntryDirty = false;
         }
 
         Context.MiniStream.Flush();
+    }
+
+    internal FatStream SwitchToFatStream(long length)
+    {
+        long originalPosition = Position;
+
+        FatStream? fatStream = null;
+
+        try
+        {
+            DirectoryEntry newDirectoryEntry = DirectoryEntry.Clone();
+            fatStream = new(rootContextSite, newDirectoryEntry);
+            fatStream.SetLength(length);
+
+            Position = 0;
+            CopyTo(fatStream);
+            fatStream.Position = originalPosition;
+
+            SetLength(0);
+            isDirectoryEntryDirty = false; // Ownership of the directory entry is transferred to the new fat stream
+
+            return fatStream;
+        }
+        catch
+        {
+            try
+            {
+                fatStream?.SetLength(0);
+            }
+            finally
+            {
+                Position = originalPosition;
+                fatStream?.Dispose();
+            }
+
+            throw;
+        }
     }
 
     uint GetMiniFatChainIndexAndSectorOffset(long offset, out long sectorOffset) => (uint)Math.DivRem(offset, Context.MiniSectorSize, out sectorOffset);
@@ -149,7 +186,7 @@ internal sealed class MiniFatStream : Stream
             DirectoryEntry.StartSectorId = miniChain.Shrink(requiredChainLength);
 
         DirectoryEntry.StreamLength = value;
-        isDirty = true;
+        isDirectoryEntryDirty = true;
     }
 
     public override void Write(byte[] buffer, int offset, int count)
@@ -183,7 +220,7 @@ internal sealed class MiniFatStream : Stream
             if (position > Length)
             {
                 DirectoryEntry.StreamLength = position;
-                isDirty = true;
+                isDirectoryEntryDirty = true;
             }
             sectorOffset = 0;
             if (writeCount >= count)


### PR DESCRIPTION
Transfer ownership of the DirectoryEntry and avoid corresponding redundant flushes.

Improve exception safety.