### PR TITLE
Add 'Hancom office files' to the structured storage explorer file ext…

### DIFF
--- a/OpenMcdf.Explorer/Services/FilePickerService.cs
+++ b/OpenMcdf.Explorer/Services/FilePickerService.cs
@@ -27,6 +27,10 @@ internal sealed class FilePickerService : IFilePickerService
                 {
                     Patterns = new[] { "*.msi" },
                 },
+                new("Hancom Office files (*.hwp)")
+                {
+                    Patterns = new[] { "*.hwp" },
+                },
                 new("Office files (*.doc;*.ppt;*.pub;*.xls)")
                 {
                     Patterns = new[] { "*.xls", "*.doc", "*.ppt", "*.pub" },
@@ -49,7 +53,7 @@ internal sealed class FilePickerService : IFilePickerService
                 },
                 new("All Structured Storage files")
                 {
-                    Patterns = new[] { "Thumbs.db", "*.aaf", "*.cfs", "*.doc", "*.msg", "*.msi", "*.ppt", "*.pub", "*.suo", "*.xls" },
+                    Patterns = new[] { "Thumbs.db", "*.aaf", "*.cfs", "*.doc", "*.hwp", "*.msg", "*.msi", "*.ppt", "*.pub", "*.suo", "*.xls" },
                 },
                 new("All files (*.*)")
                 {

--- a/StructuredStorageExplorer/MainForm.Designer.cs
+++ b/StructuredStorageExplorer/MainForm.Designer.cs
@@ -87,7 +87,7 @@
             // openFileDialog
             // 
             openFileDialog.Filter = resources.GetString("openFileDialog.Filter");
-            openFileDialog.FilterIndex = 8;
+            openFileDialog.FilterIndex = 9;
             openFileDialog.Title = "Open Structured Storage file";
             // 
             // treeView

--- a/StructuredStorageExplorer/MainForm.resx
+++ b/StructuredStorageExplorer/MainForm.resx
@@ -121,7 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="openFileDialog.Filter" xml:space="preserve">
-    <value>Advanced Authoring Format files (*.aaf)|*.aaf|MSI Setup files (*.msi)|*.msi|Office files (*.doc;*.ppt;*.pub;*.xls)|*.xls;*.doc;*.ppt|OpenMcdf Test files (*.cfs)|*.cfs|Outlook messages (*.msg)|*.msg|Thumbnail cache files (Thumbs.db)|Thumbs.db|Solution User Options files (*.suo)|*.suo|All Structured Storage files|Thumbs.db;*.aaf;*.cfs;*.doc;*.msg;*.msi;*.ppt;*.pub;*.suo;*.xls|All files (*.*)|*.*</value>
+    <value>Advanced Authoring Format files (*.aaf)|*.aaf|MSI Setup files (*.msi)|*.msi|Office files (*.doc;*.ppt;*.pub;*.xls)|*.xls;*.doc;*.ppt|OpenMcdf Test files (*.cfs)|*.cfs|Outlook messages (*.msg)|*.msg|Thumbnail cache files (Thumbs.db)|Thumbs.db|Solution User Options files (*.suo)|*.suo|Hancom Office files (*.hwp)|*.hwp|All Structured Storage files|Thumbs.db;*.aaf;*.cfs;*.doc;*.hwp;*.msg;*.msi;*.ppt;*.pub;*.suo;*.xls|All files (*.*)|*.*</value>
   </data>
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>147, 17</value>


### PR DESCRIPTION
…ension list

I might be developing a need to be able to read metadata from 'Hancom office' ('HWP') files, which are a type of compound document based office format apparently popular in South Korea.

Structured storage explorer is already able to read the outer structure of the files:

<img width="598" height="631" alt="image" src="https://github.com/user-attachments/assets/0917fd78-bb06-432a-8795-30624d5a355b" />

So would there be any opposition to adding them to the known extensions list in the UI viewer apps?

(It can't currently parse the 'HwpSummaryInformation' stream because it doesn't quite obey the Microsoft specifications for property set streams that are currently enforced here, but I'll open another issue about that later)

Thanks