### PR TITLE
Add 'HwpSummaryInformation' to the set of known property containers

### DIFF
--- a/OpenMcdf.Ole/FormatIdentifiers.cs
+++ b/OpenMcdf.Ole/FormatIdentifiers.cs
@@ -8,4 +8,5 @@ public static class FormatIdentifiers
     public static readonly Guid GlobalInfo = new("{56616F00-C154-11CE-8553-00AA00A1F95B}");
     public static readonly Guid ImageContents = new("{56616400-C154-11CE-8553-00AA00A1F95B}");
     public static readonly Guid ImageInfo = new("{56616500-C154-11CE-8553-00AA00A1F95B}");
+    public static readonly Guid HwpSummaryInformation = new("{9FA2B660-1061-11D4-B4C6-006097C09D8C}");
 }

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -11,6 +11,7 @@ public enum ContainerType
     GlobalInfo = 4,
     ImageContents = 5,
     ImageInfo = 6,
+    HwpSummaryInfo = 7,
 }
 
 public class OlePropertiesContainer
@@ -310,6 +311,8 @@ public class OlePropertiesContainer
             return ContainerType.ImageContents;
         else if (fmtId0 == FormatIdentifiers.UserDefinedProperties)
             return ContainerType.UserDefinedProperties;
+        else if (fmtId0 == FormatIdentifiers.HwpSummaryInformation)
+            return ContainerType.HwpSummaryInfo;
 
         return ContainerType.AppSpecific;
     }
@@ -325,6 +328,7 @@ public class OlePropertiesContainer
             ContainerType.ImageContents => FormatIdentifiers.ImageContents,
             ContainerType.ImageInfo => FormatIdentifiers.ImageInfo,
             ContainerType.UserDefinedProperties => FormatIdentifiers.UserDefinedProperties,
+            ContainerType.HwpSummaryInfo => FormatIdentifiers.HwpSummaryInformation,
             _ => FormatIdentifiers.DocSummaryInformation,
         };
     }

--- a/OpenMcdf.Ole/PropertySetNames.cs
+++ b/OpenMcdf.Ole/PropertySetNames.cs
@@ -13,4 +13,5 @@ public static class PropertySetNames
     public const string GlobalInfo = "\u0005GlobalInfo";
     public const string ImageContents = "\u000505ImageContents";
     public const string ImageInfo = "\u0005ImageInfo";
+    public const string HwpSummaryInformation = "\u0005HwpSummaryInformation";
 }


### PR DESCRIPTION
refs #394 

This just adds the set information to the set of known identifiers, it doesn't do anything with it yet.

I have done some local testing, and this plus a change to the stream loading to not fail altogether when there is no explicit codepage specified is sufficent to load the stream from a hwp file created by https://hwp.polarisoffice.com - can add it all in one go if preferred.