### PR TITLE
Update Avalonia to 11.3.14 to pick up a CVE fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,14 +5,14 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Android" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.iOS" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageVersion Include="Avalonia" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Android" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.iOS" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.14" />
     <PackageVersion Include="AvaloniaHex" Version="0.1.12" />
     <PackageVersion Include="Be.Windows.Forms.HexBox.Net5" Version="1.8.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
This is brought in by Avalonia and currently causes a warning about https://github.com/advisories/GHSA-xrw6-gwf8-vvr9

Maybe this isn't really that important, but this should fix the warning anyway