### PR TITLE
Handle VT_NULL properties in PropertyFactory.CreateProperty

### DIFF
--- a/OpenMcdf.Ole.Tests/PropertyFactoryTests.cs
+++ b/OpenMcdf.Ole.Tests/PropertyFactoryTests.cs
@@ -11,6 +11,7 @@ public class PropertyFactoryTests
     public static IEnumerable<object[]> SupportedScalarRoundTripCases()
     {
         yield return new object[] { VTPropertyType.VT_EMPTY, null! };
+        yield return new object[] { VTPropertyType.VT_NULL, null! };
         yield return new object[] { VTPropertyType.VT_I1, (sbyte)-12 };
         yield return new object[] { VTPropertyType.VT_I2, (short)-1234 };
         yield return new object[] { VTPropertyType.VT_I4, -1234567 };

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -34,6 +34,7 @@ internal abstract class PropertyFactory
             VTPropertyType.VT_DECIMAL => new VT_DECIMAL_Property(vType, isVariant),
             VTPropertyType.VT_BOOL => new VT_BOOL_Property(vType, isVariant),
             VTPropertyType.VT_EMPTY => new VT_EMPTY_Property(vType, isVariant),
+            VTPropertyType.VT_NULL => new VT_NULL_Property(vType, isVariant),
             VTPropertyType.VT_VARIANT_VECTOR => new VT_VariantVector(vType, codePage, isVariant, this, propertyIdentifier),
             VTPropertyType.VT_CF => new VT_CF_Property(vType, isVariant),
             VTPropertyType.VT_BLOB_OBJECT or VTPropertyType.VT_BLOB => new VT_BLOB_Property(vType, isVariant),
@@ -54,6 +55,15 @@ internal abstract class PropertyFactory
         {
         }
 
+        public override object? ReadScalarValue(BinaryReader br) => null;
+
+        public override void WriteScalarValue(BinaryWriter bw, object pValue)
+        {
+        }
+    }
+
+    private sealed class VT_NULL_Property(VTPropertyType vType, bool isVariant) : TypedPropertyValue<object>(vType, isVariant)
+    {
         public override object? ReadScalarValue(BinaryReader br) => null;
 
         public override void WriteScalarValue(BinaryWriter bw, object pValue)


### PR DESCRIPTION
It currently throws when it sees a VT_NULL property and I don't think it should.

It's a draft because I made it use VT_EMPTY_Property, but could add a VT_NULL_Property instead if wanted.