### PR TITLE
Change PropertySet.LoadContext to explicitly check for a codepage pro…

### DIFF
--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -15,7 +15,13 @@ internal sealed class PropertySet
         long currPos = br.BaseStream.Position;
 
         // Read the code page - this should always be present
-        int codePageOffset = (int)(propertySetOffset + PropertyIdentifierAndOffsets.First(pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.CodePage).Offset);
+        PropertyIdentifierAndOffset? codePageProperty = PropertyIdentifierAndOffsets.FirstOrDefault(pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.CodePage);
+        if (codePageProperty is null)
+        {
+            throw new FileFormatException("Required CodePage property not present");
+        }
+
+        int codePageOffset = (int)(propertySetOffset + codePageProperty.Offset);
         br.BaseStream.Seek(codePageOffset, SeekOrigin.Begin);
 
         var vType = (VTPropertyType)br.ReadUInt16();


### PR DESCRIPTION
…perty being present

Rather than letting 'PropertyIdentifierAndOffsets.First' throw a generic exception

Just a thought when doing https://github.com/ironfede/openmcdf/pull/395 - I think this should be explicit rather than just letting  'First' throw?