### PR TITLE
Tweak DictionaryProperty.ReadEntry to avoid string trimmimg

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -63,7 +63,10 @@ internal sealed class DictionaryProperty : IProperty
             nameBytes = br.ReadBytes(length);
         }
 
-        string entryName = Encoding.GetEncoding(codePage).GetString(nameBytes).Trim('\0');
+        int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
+        int nonNullSize = Math.Max(0, nameBytes.Length - nullByteCount);
+
+        string entryName = Encoding.GetEncoding(codePage).GetString(nameBytes, 0, nonNullSize);
         entries!.Add(propertyIdentifier, entryName);
     }
 


### PR DESCRIPTION
Just a thought based on the approach at https://github.com/OpenMcdf/openmcdf/blob/072ed2204f1d4819f976a62b06df6eb41815c3c0/OpenMcdf.Ole/PropertyFactory.cs#L316, as trimming the string can result in the string being copied and that approach avoids that.

Using the benchmarks from https://github.com/OpenMcdf/openmcdf/pull/408:

Before
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.619 us | 0.2364 us | 0.0130 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 6.224 us | 0.4761 us | 0.0261 us | 0.2441 |   5.34 KB |
| ReadWinUnicodeDocumentSummaryInformation | 6.573 us | 0.2936 us | 0.0161 us | 0.3967 |   6.59 KB |
```

After
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.666 us | 0.1996 us | 0.0109 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 6.036 us | 0.6611 us | 0.0362 us | 0.3204 |   5.26 KB |
| ReadWinUnicodeDocumentSummaryInformation | 6.349 us | 0.2099 us | 0.0115 us | 0.3891 |   6.43 KB |
```