### PR TITLE
Tweak padding handling in DictionaryProperty

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -35,10 +35,7 @@ internal sealed class DictionaryProperty : IProperty
 
         if (m > 0)
         {
-            for (int i = 0; i < m; i++)
-            {
-                br.ReadByte();
-            }
+            SkipPadding(br, m);
         }
     }
 
@@ -56,7 +53,7 @@ internal sealed class DictionaryProperty : IProperty
 
             int m = length * 2 % 4;
             if (m > 0)
-                br.ReadBytes(m);
+                SkipPadding(br, m);
         }
         else
         {
@@ -134,5 +131,16 @@ internal sealed class DictionaryProperty : IProperty
             for (int i = 0; i < 4 - m; i++) // padding
                 bw.Write((byte)0);
         }
+    }
+
+    // Read the specified number of passing bytes. Keep this so that we know it's only doing a stack alloc of 1-3 bytes
+    static void SkipPadding(BinaryReader br, int count)
+    {
+#if NETSTANDARD2_0
+        br.ReadBytes(count);
+#else
+        Span<byte> localBuffer = stackalloc byte[count];
+        br.Read(localBuffer);
+#endif
     }
 }


### PR DESCRIPTION
Just testing with something similar to #409 in the dictionary handling.

Current benchmarks
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.619 us | 0.2364 us | 0.0130 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 6.224 us | 0.4761 us | 0.0261 us | 0.2441 |   5.34 KB |
| ReadWinUnicodeDocumentSummaryInformation | 6.573 us | 0.2936 us | 0.0161 us | 0.3967 |   6.59 KB |
```

with this change
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.668 us | 0.3607 us | 0.0198 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 6.050 us | 0.3353 us | 0.0184 us | 0.3204 |   5.34 KB |
| ReadWinUnicodeDocumentSummaryInformation | 6.403 us | 0.5913 us | 0.0324 us | 0.3967 |   6.53 KB |
```

(Only really effects strings stored as CP_WINUNICODE)