### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -1,5 +1,8 @@
 name: Create a (Pre)release on NuGet
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/openmcdf/openmcdf/security/code-scanning/2](https://github.com/openmcdf/openmcdf/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/release-nuget.yml` at the workflow root (preferred here since there is one job).  
Use least privilege: `contents: read` is sufficient for `actions/checkout` and does not change functional behavior of packing/pushing to NuGet via external API key.

### What to change
- File: `.github/workflows/release-nuget.yml`
- Region: directly after `name:` (before `on:`)
- Add:
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
