### PR TITLE
Fix presubmit workflow permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/openmcdf/openmcdf/security/code-scanning/1](https://github.com/openmcdf/openmcdf/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged regardless of repo/org defaults.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), with `contents: read` as the minimal required scope for checkout and build/test operations.

Change file: **`.github/workflows/dotnet-desktop.yml`**  
Insert directly after the `on:` trigger block (before `jobs:`):

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
