### PR TITLE
[Testing] tweaks to data reading in Ole files

### DIFF
--- a/OpenMcdf.Ole.Tests/OpenMcdf.Ole.Tests.csproj
+++ b/OpenMcdf.Ole.Tests/OpenMcdf.Ole.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) == false">net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net48;net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) == false">net10.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net48;net10.0-windows;net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>

--- a/OpenMcdf.Ole.Tests/PropertyFactoryTests.cs
+++ b/OpenMcdf.Ole.Tests/PropertyFactoryTests.cs
@@ -44,7 +44,7 @@ public class PropertyFactoryTests
     {
         PropertyFactory factory = DefaultPropertyFactory.Default;
 
-        ITypedPropertyValue property = factory.CreateProperty(vType, CodePage, PropertyIdentifier);
+        ITypedPropertyValue property = factory.CreateProperty(vType, CodePage, Encoding.GetEncoding(CodePage), PropertyIdentifier);
 
         using var ms = new MemoryStream();
         using (var bw = new BinaryWriter(ms, Encoding.UTF8, true))
@@ -53,7 +53,7 @@ public class PropertyFactoryTests
             property.Write(bw);
         }
 
-        ITypedPropertyValue property2 = factory.CreateProperty(vType, CodePage, PropertyIdentifier);
+        ITypedPropertyValue property2 = factory.CreateProperty(vType, CodePage, Encoding.GetEncoding(CodePage), PropertyIdentifier);
         ms.Position = 0;
         using var br = new BinaryReader(ms, Encoding.UTF8, true);
         var actualType = (VTPropertyType)br.ReadUInt16();

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace OpenMcdf.Ole;
 
 internal static class BinaryReaderExtensions
@@ -14,4 +16,50 @@ internal static class BinaryReaderExtensions
             br.ReadExactly(localBuffer);
         }
     }
+
+    public static Guid ReadGuid(this BinaryReader br)
+    {
+#if NETSTANDARD2_0
+        byte[] localBuffer = new byte[16];
+        br.ReadExactly(localBuffer);
+        return new Guid(localBuffer);
+#else
+        Span<byte> localBuffer = stackalloc byte[16];
+        br.ReadExactly(localBuffer);
+        return new Guid(localBuffer);
+#endif
+    }
+
+    // Read a null terminated string from the specified BinaryReader, using the specified length and codepage
+    // Note: Encoding.GetEncoding seems to actually be quite slow, so allow callers that already have the Encoding to provide it directly.
+    public static string ReadNullTerminatedStringWithEncoding(this BinaryReader target, int byteLength, int codePage, Encoding encoding)
+    {
+#if NETSTANDARD2_0
+        byte[] nameBytes = new byte[byteLength];
+        target.ReadExactly(nameBytes.AsSpan());
+#else
+        // @@TBD@@ What max stack alloc size should be used here?
+        // Office limits many properties to 255 characters (e.g see the list in https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-oshared/3394ba97-9ea3-4b52-ba45-555bb5b8e94c) so we could use
+        // that, but mostly they're much smaller so maybe that's overkill.
+        Span<byte> nameBytes = byteLength <= 64 ? stackalloc byte[byteLength] : new byte[byteLength];
+        target.ReadExactly(nameBytes);
+#endif
+
+        int nullByteCount = codePage == CodePages.WinUnicode ? 2 : 1;
+        int valueSize = Math.Max(0, nameBytes.Length - nullByteCount); // Only convert the actual characters, not the null terminator
+
+#if NETSTANDARD2_0
+        return encoding.GetString(nameBytes, 0, valueSize);
+#else
+        return encoding.GetString(nameBytes[..valueSize]);
+#endif
+    }
+
+    public static string ReadNullTerminatedString(this BinaryReader target, int byteLength, int codePage)
+    {
+        Encoding encoding = codePage == CodePages.WinUnicode ? Encoding.Unicode : Encoding.GetEncoding(codePage);
+        return target.ReadNullTerminatedStringWithEncoding(byteLength, codePage, encoding);
+    }
+
+    public static string ReadNullTerminatedWideString(this BinaryReader target, int characterLength) => target.ReadNullTerminatedStringWithEncoding(byteLength: characterLength * 2, CodePages.WinUnicode, Encoding.Unicode);
 }

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -32,7 +32,7 @@ internal static class BinaryReaderExtensions
 
     // Read a null terminated string from the specified BinaryReader, using the specified length and codepage
     // Note: Encoding.GetEncoding seems to actually be quite slow, so allow callers that already have the Encoding to provide it directly.
-    public static string ReadNullTerminatedStringWithEncoding(this BinaryReader target, int byteLength, int codePage, Encoding encoding)
+    public static string ReadNullTerminatedStringWithEncoding(this BinaryReader target, int byteLength, Encoding encoding)
     {
 #if NETSTANDARD2_0
         byte[] nameBytes = new byte[byteLength];
@@ -45,7 +45,7 @@ internal static class BinaryReaderExtensions
         target.ReadExactly(nameBytes);
 #endif
 
-        int nullByteCount = codePage == CodePages.WinUnicode ? 2 : 1;
+        int nullByteCount = encoding.CodePage == CodePages.WinUnicode ? 2 : 1;
         int valueSize = Math.Max(0, nameBytes.Length - nullByteCount); // Only convert the actual characters, not the null terminator
 
 #if NETSTANDARD2_0
@@ -55,5 +55,5 @@ internal static class BinaryReaderExtensions
 #endif
     }
 
-    public static string ReadNullTerminatedWideString(this BinaryReader target, int characterLength) => target.ReadNullTerminatedStringWithEncoding(byteLength: characterLength * 2, CodePages.WinUnicode, Encoding.Unicode);
+    public static string ReadNullTerminatedWideString(this BinaryReader target, int characterLength) => target.ReadNullTerminatedStringWithEncoding(byteLength: characterLength * 2, Encoding.Unicode);
 }

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -55,11 +55,5 @@ internal static class BinaryReaderExtensions
 #endif
     }
 
-    public static string ReadNullTerminatedString(this BinaryReader target, int byteLength, int codePage)
-    {
-        Encoding encoding = codePage == CodePages.WinUnicode ? Encoding.Unicode : Encoding.GetEncoding(codePage);
-        return target.ReadNullTerminatedStringWithEncoding(byteLength, codePage, encoding);
-    }
-
     public static string ReadNullTerminatedWideString(this BinaryReader target, int characterLength) => target.ReadNullTerminatedStringWithEncoding(byteLength: characterLength * 2, CodePages.WinUnicode, Encoding.Unicode);
 }

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -30,9 +30,9 @@ internal static class BinaryReaderExtensions
 #endif
     }
 
-    // Read a null terminated string from the specified BinaryReader, using the specified length and codepage
+    // Read a null terminated string from the specified BinaryReader, using the specified length Encoding
     // Note: Encoding.GetEncoding seems to actually be quite slow, so allow callers that already have the Encoding to provide it directly.
-    public static string ReadNullTerminatedStringWithEncoding(this BinaryReader target, int byteLength, Encoding encoding)
+    public static string ReadCodePageString(this BinaryReader target, int byteLength, Encoding encoding)
     {
 #if NETSTANDARD2_0
         byte[] nameBytes = new byte[byteLength];
@@ -55,5 +55,5 @@ internal static class BinaryReaderExtensions
 #endif
     }
 
-    public static string ReadNullTerminatedWideString(this BinaryReader target, int characterLength) => target.ReadNullTerminatedStringWithEncoding(byteLength: characterLength * 2, Encoding.Unicode);
+    public static string ReadUnicodeString(this BinaryReader target, int characterLength) => target.ReadCodePageString(byteLength: characterLength * 2, Encoding.Unicode);
 }

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -1,0 +1,17 @@
+namespace OpenMcdf.Ole;
+
+internal static class BinaryReaderExtensions
+{
+#if !NET10_0_OR_GREATER
+    public static void ReadExactly(this BinaryReader target, Span<byte> buffer) => target.BaseStream.ReadExactly(buffer);
+#endif
+
+    public static void SkipPadding(this BinaryReader br, int count)
+    {
+        if (count > 0)
+        {
+            Span<byte> localBuffer = stackalloc byte[count];
+            br.ReadExactly(localBuffer);
+        }
+    }
+}

--- a/OpenMcdf.Ole/CodePages.cs
+++ b/OpenMcdf.Ole/CodePages.cs
@@ -1,6 +1,22 @@
-﻿namespace OpenMcdf.Ole;
+﻿using System.Text;
+
+namespace OpenMcdf.Ole;
 
 internal static class CodePages
 {
     public const int WinUnicode = 0x04B0;
+    public const int UTF8 = 65001;
+
+    // Get the encoding for the specified codepage
+    // Special case WinUnicode because it's special cases in general, and it's faster to get it directly than to call GetEndoding.
+    // @@TODO@@ Is it worth special caseing UTF-8 as well?
+    internal static Encoding GetEncodingForCodePage(int codePage)
+    {
+        return codePage switch
+        {
+            WinUnicode => Encoding.Unicode,
+            UTF8 => Encoding.UTF8,
+            _ => Encoding.GetEncoding(codePage),
+        };
+    }
 }

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -5,11 +5,13 @@ namespace OpenMcdf.Ole;
 internal sealed class DictionaryProperty : IProperty
 {
     private readonly int codePage;
+    private readonly Encoding encoding;
     private Dictionary<uint, string>? entries = new();
 
-    public DictionaryProperty(int codePage)
+    public DictionaryProperty(int codePage, Encoding encoding)
     {
         this.codePage = codePage;
+        this.encoding = encoding;
     }
 
     public PropertyType PropertyType => PropertyType.DictionaryProperty;
@@ -26,12 +28,9 @@ internal sealed class DictionaryProperty : IProperty
 
         uint numEntries = br.ReadUInt32();
 
-        // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
-        Encoding? encoding = null;
-
         for (uint i = 0; i < numEntries; i++)
         {
-            ReadEntry(br, ref encoding);
+            ReadEntry(br);
         }
 
         int m = (int)(br.BaseStream.Position - curPos) % 4;
@@ -43,7 +42,7 @@ internal sealed class DictionaryProperty : IProperty
     }
 
     // Read a single dictionary entry
-    private void ReadEntry(BinaryReader br, ref Encoding? encoding)
+    private void ReadEntry(BinaryReader br)
     {
         uint propertyIdentifier = br.ReadUInt32();
         int length = br.ReadInt32();
@@ -61,9 +60,7 @@ internal sealed class DictionaryProperty : IProperty
         }
         else
         {
-            // Get the encoding on first use -it's the same for all properties in the dictionary
-            encoding ??= Encoding.GetEncoding(this.codePage);
-            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.codePage, encoding);
+            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.codePage, this.encoding);
         }
 
         entries!.Add(propertyIdentifier, entryName);
@@ -82,12 +79,9 @@ internal sealed class DictionaryProperty : IProperty
 
         bw.Write(entries!.Count);
 
-        // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
-        Encoding encoding = Encoding.GetEncoding(codePage);
-
         foreach (KeyValuePair<uint, string> kv in entries)
         {
-            WriteEntry(bw, kv.Key, kv.Value, encoding);
+            WriteEntry(bw, kv.Key, kv.Value);
         }
 
         int size = (int)(bw.BaseStream.Position - curPos);
@@ -95,7 +89,7 @@ internal sealed class DictionaryProperty : IProperty
     }
 
     // Write a single entry to the dictionary, and handle and required null termination and padding.
-    private void WriteEntry(BinaryWriter bw, uint propertyIdentifier, string name, Encoding encoding)
+    private void WriteEntry(BinaryWriter bw, uint propertyIdentifier, string name)
     {
         // Write the PropertyIdentifier
         bw.Write(propertyIdentifier);

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -38,10 +38,7 @@ internal sealed class DictionaryProperty : IProperty
 
         if (m > 0)
         {
-            for (int i = 0; i < m; i++)
-            {
-                br.ReadByte();
-            }
+            br.SkipPadding(m);
         }
     }
 
@@ -50,26 +47,22 @@ internal sealed class DictionaryProperty : IProperty
     {
         uint propertyIdentifier = br.ReadUInt32();
         int length = br.ReadInt32();
-
-        byte[] nameBytes;
+        int byteLength = length;
+        int paddingLength = 0;
 
         if (codePage == CodePages.WinUnicode)
         {
-            nameBytes = br.ReadBytes(length << 1);
+            paddingLength = length * 2 % 4;
+            byteLength = (length << 1) + paddingLength;
+        }
 
-            int m = length * 2 % 4;
-            if (m > 0)
-                br.ReadBytes(m);
-        }
-        else
-        {
-            nameBytes = br.ReadBytes(length);
-        }
+        byte[] nameBytes = new byte[byteLength];
+        br.ReadExactly(nameBytes);
 
         int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
-        int nonNullSize = Math.Max(0, nameBytes.Length - nullByteCount);
+        int valueSize = Math.Max(0, nameBytes.Length - nullByteCount - paddingLength); // Only convert the actual characters, not the null terminator or padding
 
-        string entryName = encoding.GetString(nameBytes, 0, nonNullSize);
+        string entryName = encoding.GetString(nameBytes, 0, valueSize);
         entries!.Add(propertyIdentifier, entryName);
     }
 

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -60,7 +60,7 @@ internal sealed class DictionaryProperty : IProperty
         }
         else
         {
-            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.codePage, this.encoding);
+            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.encoding);
         }
 
         entries!.Add(propertyIdentifier, entryName);

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -27,11 +27,11 @@ internal sealed class DictionaryProperty : IProperty
         uint numEntries = br.ReadUInt32();
 
         // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
-        Encoding encoding = Encoding.GetEncoding(codePage);
+        Encoding? encoding = null;
 
         for (uint i = 0; i < numEntries; i++)
         {
-            ReadEntry(br, encoding);
+            ReadEntry(br, ref encoding);
         }
 
         int m = (int)(br.BaseStream.Position - curPos) % 4;
@@ -43,26 +43,29 @@ internal sealed class DictionaryProperty : IProperty
     }
 
     // Read a single dictionary entry
-    private void ReadEntry(BinaryReader br, Encoding encoding)
+    private void ReadEntry(BinaryReader br, ref Encoding? encoding)
     {
         uint propertyIdentifier = br.ReadUInt32();
         int length = br.ReadInt32();
-        int byteLength = length;
-        int paddingLength = 0;
 
+        string entryName;
+
+        // WinUnicode properties are padded so the length is a multiple of 4 bytes. We need to skip that padding.
         if (codePage == CodePages.WinUnicode)
         {
-            paddingLength = length * 2 % 4;
-            byteLength = (length << 1) + paddingLength;
+            entryName = br.ReadNullTerminatedWideString(length);
+
+            int paddingLength = length * 2 % 4;
+            if (paddingLength > 0)
+                br.SkipPadding(paddingLength);
+        }
+        else
+        {
+            // Get the encoding on first use -it's the same for all properties in the dictionary
+            encoding ??= Encoding.GetEncoding(this.codePage);
+            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.codePage, encoding);
         }
 
-        byte[] nameBytes = new byte[byteLength];
-        br.ReadExactly(nameBytes);
-
-        int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
-        int valueSize = Math.Max(0, nameBytes.Length - nullByteCount - paddingLength); // Only convert the actual characters, not the null terminator or padding
-
-        string entryName = encoding.GetString(nameBytes, 0, valueSize);
         entries!.Add(propertyIdentifier, entryName);
     }
 

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -52,7 +52,7 @@ internal sealed class DictionaryProperty : IProperty
         // WinUnicode properties are padded so the length is a multiple of 4 bytes. We need to skip that padding.
         if (codePage == CodePages.WinUnicode)
         {
-            entryName = br.ReadNullTerminatedWideString(length);
+            entryName = br.ReadUnicodeString(length);
 
             int paddingLength = length * 2 % 4;
             if (paddingLength > 0)
@@ -60,7 +60,7 @@ internal sealed class DictionaryProperty : IProperty
         }
         else
         {
-            entryName = br.ReadNullTerminatedStringWithEncoding(length, this.encoding);
+            entryName = br.ReadCodePageString(length, this.encoding);
         }
 
         entries!.Add(propertyIdentifier, entryName);

--- a/OpenMcdf.Ole/DocumentSummaryInfoPropertyFactory.cs
+++ b/OpenMcdf.Ole/DocumentSummaryInfoPropertyFactory.cs
@@ -1,16 +1,18 @@
-﻿namespace OpenMcdf.Ole;
+﻿using System.Text;
+
+namespace OpenMcdf.Ole;
 
 // A separate factory for DocumentSummaryInformation properties, to handle special cases with unaligned strings.
 internal sealed class DocumentSummaryInfoPropertyFactory : PropertyFactory
 {
     public static DocumentSummaryInfoPropertyFactory Default { get; } = new();
 
-    protected override ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant)
+    protected override ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, Encoding encoding, uint propertyIdentifier, bool isVariant)
     {
         // PIDDSI_HEADINGPAIR and PIDDSI_DOCPARTS use unaligned (unpadded) strings - the others are padded
         if (propertyIdentifier is 0x0000000C or 0x0000000D)
-            return new VT_Unaligned_LPSTR_Property(vType, codePage, isVariant);
+            return new VT_Unaligned_LPSTR_Property(vType, codePage, encoding, isVariant);
 
-        return base.CreateLpstrProperty(vType, codePage, propertyIdentifier, isVariant);
+        return base.CreateLpstrProperty(vType, codePage, encoding, propertyIdentifier, isVariant);
     }
 }

--- a/OpenMcdf.Ole/DocumentSummaryInfoPropertyFactory.cs
+++ b/OpenMcdf.Ole/DocumentSummaryInfoPropertyFactory.cs
@@ -7,12 +7,12 @@ internal sealed class DocumentSummaryInfoPropertyFactory : PropertyFactory
 {
     public static DocumentSummaryInfoPropertyFactory Default { get; } = new();
 
-    protected override ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, Encoding encoding, uint propertyIdentifier, bool isVariant)
+    protected override ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, Encoding encoding, uint propertyIdentifier, bool isVariant)
     {
         // PIDDSI_HEADINGPAIR and PIDDSI_DOCPARTS use unaligned (unpadded) strings - the others are padded
         if (propertyIdentifier is 0x0000000C or 0x0000000D)
-            return new VT_Unaligned_LPSTR_Property(vType, codePage, encoding, isVariant);
+            return new VT_Unaligned_LPSTR_Property(vType, encoding, isVariant);
 
-        return base.CreateLpstrProperty(vType, codePage, encoding, propertyIdentifier, isVariant);
+        return base.CreateLpstrProperty(vType, encoding, propertyIdentifier, isVariant);
     }
 }

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -260,9 +260,11 @@ public class OlePropertiesContainer
         PropertyFactory factory =
             ContainerType == ContainerType.DocumentSummaryInfo ? DocumentSummaryInfoPropertyFactory.Default : DefaultPropertyFactory.Default;
 
+        Encoding propertySet0Encoding = CodePages.GetEncodingForCodePage(ps.PropertySet0.PropertyContext.CodePage);
+
         foreach (OleProperty op in Properties)
         {
-            ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, op.PropertyIdentifier);
+            ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, propertySet0Encoding, op.PropertyIdentifier);
             p.Value = op.Value;
             ps.PropertySet0.Properties.Add(p);
             ps.PropertySet0.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
@@ -283,10 +285,12 @@ public class OlePropertiesContainer
             // Add the dictionary containing the property names
             ps.PropertySet1.Add(UserDefinedProperties.PropertyNames!);
 
+            Encoding propertySet1Encoding = CodePages.GetEncodingForCodePage(ps.PropertySet1.PropertyContext.CodePage);
+
             // Add the properties themselves
             foreach (OleProperty op in UserDefinedProperties.Properties)
             {
-                ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, op.PropertyIdentifier);
+                ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, propertySet1Encoding, op.PropertyIdentifier);
                 p.Value = op.Value;
                 ps.PropertySet1.Properties.Add(p);
                 ps.PropertySet1.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -248,9 +248,11 @@ public class OlePropertiesContainer
         PropertyFactory factory =
             ContainerType == ContainerType.DocumentSummaryInfo ? DocumentSummaryInfoPropertyFactory.Default : DefaultPropertyFactory.Default;
 
+        Encoding propertySet0Encoding = CodePages.GetEncodingForCodePage(ps.PropertySet0.PropertyContext.CodePage);
+
         foreach (OleProperty op in Properties)
         {
-            ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, op.PropertyIdentifier);
+            ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, propertySet0Encoding, op.PropertyIdentifier);
             p.Value = op.Value;
             ps.PropertySet0.Properties.Add(p);
             ps.PropertySet0.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
@@ -271,10 +273,12 @@ public class OlePropertiesContainer
             // Add the dictionary containing the property names
             ps.PropertySet1.Add(UserDefinedProperties.PropertyNames!);
 
+            Encoding propertySet1Encoding = CodePages.GetEncodingForCodePage(ps.PropertySet1.PropertyContext.CodePage);
+
             // Add the properties themselves
             foreach (OleProperty op in UserDefinedProperties.Properties)
             {
-                ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, op.PropertyIdentifier);
+                ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, propertySet1Encoding, op.PropertyIdentifier);
                 p.Value = op.Value;
                 ps.PropertySet1.Properties.Add(p);
                 ps.PropertySet1.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));

--- a/OpenMcdf.Ole/OpenMcdf.Ole.csproj
+++ b/OpenMcdf.Ole/OpenMcdf.Ole.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
 

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -27,8 +27,8 @@ internal abstract class PropertyFactory
             VTPropertyType.VT_UI2 => new VT_UI2_Property(vType, isVariant),
             VTPropertyType.VT_UI4 => new VT_UI4_Property(vType, isVariant),
             VTPropertyType.VT_UI8 => new VT_UI8_Property(vType, isVariant),
-            VTPropertyType.VT_BSTR => new VT_LPSTR_Property(vType, codePage, encoding, isVariant),
-            VTPropertyType.VT_LPSTR => CreateLpstrProperty(vType, codePage, encoding, propertyIdentifier, isVariant),
+            VTPropertyType.VT_BSTR => new VT_LPSTR_Property(vType, encoding, isVariant),
+            VTPropertyType.VT_LPSTR => CreateLpstrProperty(vType, encoding, propertyIdentifier, isVariant),
             VTPropertyType.VT_LPWSTR => new VT_LPWSTR_Property(vType, isVariant),
             VTPropertyType.VT_FILETIME => new VT_FILETIME_Property(vType, isVariant),
             VTPropertyType.VT_DECIMAL => new VT_DECIMAL_Property(vType, isVariant),
@@ -44,7 +44,7 @@ internal abstract class PropertyFactory
         return pr;
     }
 
-    protected virtual ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, Encoding encoding, uint propertyIdentifier, bool isVariant) => new VT_LPSTR_Property(vType, codePage, encoding, isVariant);
+    protected virtual ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, Encoding encoding, uint propertyIdentifier, bool isVariant) => new VT_LPSTR_Property(vType, encoding, isVariant);
 
     #region Property implementations
 
@@ -301,20 +301,18 @@ internal abstract class PropertyFactory
 
     protected class VT_LPSTR_Property : TypedPropertyValue<string>
     {
-        private readonly int codePage;
         private readonly Encoding encoding;
 
-        public VT_LPSTR_Property(VTPropertyType vType, int codePage, Encoding encoding, bool isVariant)
+        public VT_LPSTR_Property(VTPropertyType vType, Encoding encoding, bool isVariant)
             : base(vType, isVariant)
         {
-            this.codePage = codePage;
             this.encoding = encoding;
         }
 
         public override string ReadScalarValue(BinaryReader br)
         {
             int size = (int)br.ReadUInt32();
-            return br.ReadNullTerminatedStringWithEncoding(size, codePage, encoding);
+            return br.ReadNullTerminatedStringWithEncoding(size, encoding);
         }
 
         public override void WriteScalarValue(BinaryWriter bw, string pValue)
@@ -324,7 +322,7 @@ internal abstract class PropertyFactory
             {
                 bw.Write(0U);
             }
-            else if (codePage == CodePages.WinUnicode)
+            else if (encoding.CodePage == CodePages.WinUnicode)
             {
                 byte[] data = Encoding.Unicode.GetBytes(pValue);
 
@@ -375,8 +373,8 @@ internal abstract class PropertyFactory
 
     protected sealed class VT_Unaligned_LPSTR_Property : VT_LPSTR_Property
     {
-        public VT_Unaligned_LPSTR_Property(VTPropertyType vType, int codePage, Encoding encoding, bool isVariant)
-            : base(vType, codePage, encoding, isVariant)
+        public VT_Unaligned_LPSTR_Property(VTPropertyType vType, Encoding encoding, bool isVariant)
+            : base(vType, encoding, isVariant)
         {
             NeedsPadding = false;
         }

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -312,7 +312,7 @@ internal abstract class PropertyFactory
         public override string ReadScalarValue(BinaryReader br)
         {
             int size = (int)br.ReadUInt32();
-            return br.ReadNullTerminatedStringWithEncoding(size, encoding);
+            return br.ReadCodePageString(size, encoding);
         }
 
         public override void WriteScalarValue(BinaryWriter bw, string pValue)
@@ -390,7 +390,7 @@ internal abstract class PropertyFactory
         public override string ReadScalarValue(BinaryReader br)
         {
             uint nChars = br.ReadUInt32();
-            string result = nChars > 0 ? br.ReadNullTerminatedWideString((int)nChars) : string.Empty;
+            string result = nChars > 0 ? br.ReadUnicodeString((int)nChars) : string.Empty;
 
             // result = result.Trim(new char[] { '\0' });
             return result;

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -9,7 +9,7 @@ internal abstract class PropertyFactory
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
     }
 
-    public ITypedPropertyValue CreateProperty(VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant = false)
+    public ITypedPropertyValue CreateProperty(VTPropertyType vType, int codePage, Encoding encoding, uint propertyIdentifier, bool isVariant = false)
     {
         ITypedPropertyValue pr = (VTPropertyType)((ushort)vType & 0x00FF) switch
         {
@@ -27,15 +27,15 @@ internal abstract class PropertyFactory
             VTPropertyType.VT_UI2 => new VT_UI2_Property(vType, isVariant),
             VTPropertyType.VT_UI4 => new VT_UI4_Property(vType, isVariant),
             VTPropertyType.VT_UI8 => new VT_UI8_Property(vType, isVariant),
-            VTPropertyType.VT_BSTR => new VT_LPSTR_Property(vType, codePage, isVariant),
-            VTPropertyType.VT_LPSTR => CreateLpstrProperty(vType, codePage, propertyIdentifier, isVariant),
+            VTPropertyType.VT_BSTR => new VT_LPSTR_Property(vType, codePage, encoding, isVariant),
+            VTPropertyType.VT_LPSTR => CreateLpstrProperty(vType, codePage, encoding, propertyIdentifier, isVariant),
             VTPropertyType.VT_LPWSTR => new VT_LPWSTR_Property(vType, isVariant),
             VTPropertyType.VT_FILETIME => new VT_FILETIME_Property(vType, isVariant),
             VTPropertyType.VT_DECIMAL => new VT_DECIMAL_Property(vType, isVariant),
             VTPropertyType.VT_BOOL => new VT_BOOL_Property(vType, isVariant),
             VTPropertyType.VT_EMPTY => new VT_EMPTY_Property(vType, isVariant),
             VTPropertyType.VT_NULL => new VT_NULL_Property(vType, isVariant),
-            VTPropertyType.VT_VARIANT_VECTOR => new VT_VariantVector(vType, codePage, isVariant, this, propertyIdentifier),
+            VTPropertyType.VT_VARIANT_VECTOR => new VT_VariantVector(vType, codePage, encoding, isVariant, this, propertyIdentifier),
             VTPropertyType.VT_CF => new VT_CF_Property(vType, isVariant),
             VTPropertyType.VT_BLOB_OBJECT or VTPropertyType.VT_BLOB => new VT_BLOB_Property(vType, isVariant),
             VTPropertyType.VT_CLSID => new VT_CLSID_Property(vType, isVariant),
@@ -44,7 +44,7 @@ internal abstract class PropertyFactory
         return pr;
     }
 
-    protected virtual ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant) => new VT_LPSTR_Property(vType, codePage, isVariant);
+    protected virtual ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, Encoding encoding, uint propertyIdentifier, bool isVariant) => new VT_LPSTR_Property(vType, codePage, encoding, isVariant);
 
     #region Property implementations
 
@@ -302,17 +302,19 @@ internal abstract class PropertyFactory
     protected class VT_LPSTR_Property : TypedPropertyValue<string>
     {
         private readonly int codePage;
+        private readonly Encoding encoding;
 
-        public VT_LPSTR_Property(VTPropertyType vType, int codePage, bool isVariant)
+        public VT_LPSTR_Property(VTPropertyType vType, int codePage, Encoding encoding, bool isVariant)
             : base(vType, isVariant)
         {
             this.codePage = codePage;
+            this.encoding = encoding;
         }
 
         public override string ReadScalarValue(BinaryReader br)
         {
             int size = (int)br.ReadUInt32();
-            return br.ReadNullTerminatedString(size, this.codePage);
+            return br.ReadNullTerminatedStringWithEncoding(size, codePage, encoding);
         }
 
         public override void WriteScalarValue(BinaryWriter bw, string pValue)
@@ -324,7 +326,7 @@ internal abstract class PropertyFactory
             }
             else if (codePage == CodePages.WinUnicode)
             {
-                byte[] data = Encoding.GetEncoding(codePage).GetBytes(pValue);
+                byte[] data = Encoding.Unicode.GetBytes(pValue);
 
                 // if (data.Length >= 2 && data[data.Length - 2] == '\0' && data[data.Length - 1] == '\0')
                 //    addNullTerminator = false;
@@ -348,7 +350,7 @@ internal abstract class PropertyFactory
             }
             else
             {
-                byte[] data = Encoding.GetEncoding(codePage).GetBytes(pValue);
+                byte[] data = this.encoding.GetBytes(pValue);
 
                 // if (data.Length >= 1 && data[data.Length - 1] == '\0')
                 //    addNullTerminator = false;
@@ -373,8 +375,8 @@ internal abstract class PropertyFactory
 
     protected sealed class VT_Unaligned_LPSTR_Property : VT_LPSTR_Property
     {
-        public VT_Unaligned_LPSTR_Property(VTPropertyType vType, int codePage, bool isVariant)
-            : base(vType, codePage, isVariant)
+        public VT_Unaligned_LPSTR_Property(VTPropertyType vType, int codePage, Encoding encoding, bool isVariant)
+            : base(vType, codePage, encoding, isVariant)
         {
             NeedsPadding = false;
         }
@@ -578,13 +580,15 @@ internal abstract class PropertyFactory
     private sealed class VT_VariantVector : TypedPropertyValue<object>
     {
         private readonly int codePage;
+        private readonly Encoding encoding;
         private readonly PropertyFactory factory;
         private readonly uint propertyIdentifier;
 
-        public VT_VariantVector(VTPropertyType vType, int codePage, bool isVariant, PropertyFactory factory, uint propertyIdentifier)
+        public VT_VariantVector(VTPropertyType vType, int codePage, Encoding encoding, bool isVariant, PropertyFactory factory, uint propertyIdentifier)
             : base(vType, isVariant)
         {
             this.codePage = codePage;
+            this.encoding = encoding;
             this.factory = factory;
             this.propertyIdentifier = propertyIdentifier;
             NeedsPadding = false;
@@ -595,7 +599,7 @@ internal abstract class PropertyFactory
             var vType = (VTPropertyType)br.ReadUInt16();
             br.ReadUInt16(); // Ushort Padding
 
-            ITypedPropertyValue p = factory.CreateProperty(vType, codePage, propertyIdentifier, true);
+            ITypedPropertyValue p = factory.CreateProperty(vType, codePage, encoding, propertyIdentifier, true);
             p.Read(br);
             return p;
         }

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -312,11 +312,7 @@ internal abstract class PropertyFactory
         public override string ReadScalarValue(BinaryReader br)
         {
             int size = (int)br.ReadUInt32();
-            byte[] data = br.ReadBytes(size);
-            int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
-            int nonNullSize = Math.Max(0, size - nullByteCount);
-            string result = Encoding.GetEncoding(codePage).GetString(data, 0, nonNullSize);
-            return result;
+            return br.ReadNullTerminatedString(size, this.codePage);
         }
 
         public override void WriteScalarValue(BinaryWriter bw, string pValue)
@@ -394,17 +390,7 @@ internal abstract class PropertyFactory
         public override string ReadScalarValue(BinaryReader br)
         {
             uint nChars = br.ReadUInt32();
-            string result;
-            if (nChars > 0)
-            {
-                byte[] data = br.ReadBytes((int)((nChars - 1) * 2));  // WChar- null terminator
-                br.ReadBytes(2); // Skip null terminator
-                result = Encoding.Unicode.GetString(data);
-            }
-            else
-            {
-                result = string.Empty;
-            }
+            string result = nChars > 0 ? br.ReadNullTerminatedWideString((int)nChars) : string.Empty;
 
             // result = result.Trim(new char[] { '\0' });
             return result;
@@ -581,11 +567,7 @@ internal abstract class PropertyFactory
         {
         }
 
-        public override Guid ReadScalarValue(BinaryReader br)
-        {
-            byte[] data = br.ReadBytes(16);
-            return new Guid(data);
-        }
+        public override Guid ReadScalarValue(BinaryReader br) => br.ReadGuid();
 
         public override void WriteScalarValue(BinaryWriter bw, Guid pValue)
         {

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -45,7 +45,7 @@ internal sealed class PropertySet
 
     public void Add(IDictionary<uint, string> propertyNames)
     {
-        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage)
+        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage, CodePages.GetEncodingForCodePage(PropertyContext.CodePage))
         {
             Value = propertyNames,
         };

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -47,7 +47,7 @@ internal sealed class PropertySet
 
     public void Add(IDictionary<uint, string> propertyNames)
     {
-        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage)
+        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage, CodePages.GetEncodingForCodePage(PropertyContext.CodePage))
         {
             Value = propertyNames,
         };

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -44,14 +44,14 @@ internal sealed class PropertySetStream
         ByteOrder = br.ReadUInt16();
         Version = br.ReadUInt16();
         SystemIdentifier = br.ReadUInt32();
-        CLSID = new Guid(br.ReadBytes(16));
+        CLSID = br.ReadGuid();
         NumPropertySets = br.ReadUInt32();
-        FMTID0 = new Guid(br.ReadBytes(16));
+        FMTID0 = br.ReadGuid();
         Offset0 = br.ReadUInt32();
 
         if (NumPropertySets == 2)
         {
-            FMTID1 = new Guid(br.ReadBytes(16));
+            FMTID1 = br.ReadGuid();
             Offset1 = br.ReadUInt32();
         }
 

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenMcdf.Ole;
+﻿using System.Text;
+
+namespace OpenMcdf.Ole;
 
 internal sealed class PropertySetStream
 {
@@ -73,13 +75,14 @@ internal sealed class PropertySetStream
         }
 
         PropertySet0.LoadContext((int)Offset0, br);  // Read CodePage, Locale
+        Encoding propertySet0Encoding = CodePages.GetEncodingForCodePage(PropertySet0.PropertyContext.CodePage); // Get the encoding once and use it for all properties to avoid repeasted lookups
 
         // Read properties (P0)
         for (int i = 0; i < propertyCount; i++)
         {
             PropertyIdentifierAndOffset propertyIdentifierAndOffset = PropertySet0.PropertyIdentifierAndOffsets[i];
             br.BaseStream.Seek(Offset0 + propertyIdentifierAndOffset.Offset, SeekOrigin.Begin);
-            IProperty property = ReadProperty(propertyIdentifierAndOffset.PropertyIdentifier, PropertySet0.PropertyContext.CodePage, br, factory);
+            IProperty property = ReadProperty(propertyIdentifierAndOffset.PropertyIdentifier, PropertySet0.PropertyContext.CodePage, propertySet0Encoding, br, factory);
             PropertySet0.Properties.Add(property);
         }
 
@@ -104,12 +107,16 @@ internal sealed class PropertySetStream
 
             PropertySet1.LoadContext((int)Offset1, br);
 
+            Encoding propertySet1Encoding =
+                PropertySet1.PropertyContext.CodePage == PropertySet0.PropertyContext.CodePage ? propertySet0Encoding :
+                    CodePages.GetEncodingForCodePage(PropertySet1.PropertyContext.CodePage); // Get the encoding once and use it for all properties to avoid repeasted lookups
+
             // Read properties
             for (int i = 0; i < propertyCount; i++)
             {
                 PropertyIdentifierAndOffset idAndOffset = PropertySet1.PropertyIdentifierAndOffsets[i];
                 br.BaseStream.Seek(Offset1 + idAndOffset.Offset, SeekOrigin.Begin);
-                IProperty property = ReadProperty(idAndOffset.PropertyIdentifier, PropertySet1.PropertyContext.CodePage, br, DefaultPropertyFactory.Default);
+                IProperty property = ReadProperty(idAndOffset.PropertyIdentifier, PropertySet1.PropertyContext.CodePage, propertySet1Encoding, br, DefaultPropertyFactory.Default);
                 PropertySet1.Properties.Add(property);
             }
         }
@@ -219,11 +226,11 @@ internal sealed class PropertySetStream
         }
     }
 
-    private static IProperty ReadProperty(uint propertyIdentifier, int codePage, BinaryReader br, PropertyFactory factory)
+    private static IProperty ReadProperty(uint propertyIdentifier, int codePage, Encoding encoding, BinaryReader br, PropertyFactory factory)
     {
         if (propertyIdentifier == SpecialPropertyIdentifiers.Dictionary)
         {
-            DictionaryProperty dictionaryProperty = new(codePage);
+            DictionaryProperty dictionaryProperty = new(codePage, encoding);
             dictionaryProperty.Read(br);
             return dictionaryProperty;
         }
@@ -231,7 +238,7 @@ internal sealed class PropertySetStream
         var vType = (VTPropertyType)br.ReadUInt16();
         br.ReadUInt16(); // Ushort Padding
 
-        ITypedPropertyValue pr = factory.CreateProperty(vType, codePage, propertyIdentifier);
+        ITypedPropertyValue pr = factory.CreateProperty(vType, codePage, encoding, propertyIdentifier);
         pr.Read(br);
 
         return pr;

--- a/OpenMcdf.Ole/StreamExtensions.cs
+++ b/OpenMcdf.Ole/StreamExtensions.cs
@@ -1,0 +1,49 @@
+using System.Buffers;
+
+namespace OpenMcdf.Ole;
+
+internal static class StreamExtensions
+{
+#if !NET
+    private static int Read(this Stream target, Span<byte> buffer)
+    {
+        var sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        try
+        {
+            int numRead = target.Read(sharedBuffer, 0, buffer.Length);
+            new ReadOnlySpan<byte>(sharedBuffer, 0, numRead).CopyTo(buffer);
+            return numRead;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(sharedBuffer);
+        }
+    }
+
+    public static void ReadExactly(this Stream target, Span<byte> buffer)
+    {
+        if (buffer.Length == 0)
+        {
+            return;
+        }
+
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            int read = target.Read(buffer.Slice(totalRead));
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += read;
+        }
+    }
+
+    public static void ReadExactly(this Stream stream, byte[] buffer, int offset, int count)
+    {
+        stream.ReadExactly(buffer.AsSpan(offset, count));
+    }
+
+#endif
+}

--- a/OpenMcdf.Ole/StreamExtensions.cs
+++ b/OpenMcdf.Ole/StreamExtensions.cs
@@ -1,5 +1,3 @@
-using System.Buffers;
-
 namespace OpenMcdf.Ole;
 
 internal static class StreamExtensions
@@ -7,7 +5,7 @@ internal static class StreamExtensions
 #if !NET
     private static int Read(this Stream target, Span<byte> buffer)
     {
-        var sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        var sharedBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(buffer.Length);
         try
         {
             int numRead = target.Read(sharedBuffer, 0, buffer.Length);
@@ -16,7 +14,7 @@ internal static class StreamExtensions
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(sharedBuffer);
+            System.Buffers.ArrayPool<byte>.Shared.Return(sharedBuffer);
         }
     }
 

--- a/OpenMcdf.Ole/TypedPropertyValue.cs
+++ b/OpenMcdf.Ole/TypedPropertyValue.cs
@@ -55,7 +55,7 @@ internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
                     int m = size % 4;
 
                     if (m > 0 && NeedsPadding)
-                        br.ReadBytes(4 - m); // padding
+                        br.SkipPadding(4 - m); // padding
                 }
 
                 break;
@@ -77,7 +77,7 @@ internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
 
                         int pad = itemSize % 4;
                         if (pad > 0 && NeedsPadding)
-                            br.ReadBytes(4 - pad); // padding
+                            br.SkipPadding(4 - pad); // padding
                     }
 
                     propertyValue = res;
@@ -85,7 +85,7 @@ internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
 
                     int m = size % 4;
                     if (m > 0 && NeedsPadding)
-                        br.ReadBytes(4 - m); // padding
+                        br.SkipPadding(4 - m); // padding
                 }
 
                 break;


### PR DESCRIPTION
Some musings based on comments in https://github.com/openmcdf/openmcdf/pull/409 and https://github.com/openmcdf/openmcdf/pull/411
---

Just a couple of places for testing, could be done elsewhere -
- Add a SkipPadding extension which uses ReadExactly instead of ReadBytes so that it fails when there isn't enough data, and uses stackalloc to avoid allocating lots of tiny arrays.
- Add a ReadGuid extension which uses ReadExactly so that it fails when there isn't enough data, and uses stackalloc on .NET core (where Guid has a constructor which takes a Span<byte>)
- Add some ReadString extensions which use ReadExactly so that it fails when there isn't enough data, deduplicates a bit of the null terminator handling logic, and uses stackalloc for small length strings.
- Passes the Encodings to use around instead of getting them continually. This is faster, though does make VT_LPSTR_Property instances use more memory.

Most of the complexity is pollyfilling Span based functions in .NET Standard and that can be tuned if this goes anywhere, and the same changes could be done elsewhere as well.

So, this is a combination of correctness (using ReadExactly instead of ReadBytes which might return less data than asked for), and performance (removes some allocations, removes some duplicate work)