### PR TITLE
Improve DictionaryProperty.Read/Write encoding

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -26,9 +26,12 @@ internal sealed class DictionaryProperty : IProperty
 
         uint numEntries = br.ReadUInt32();
 
+        // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
+        Encoding encoding = Encoding.GetEncoding(codePage);
+
         for (uint i = 0; i < numEntries; i++)
         {
-            ReadEntry(br);
+            ReadEntry(br, encoding);
         }
 
         int m = (int)(br.BaseStream.Position - curPos) % 4;
@@ -43,7 +46,7 @@ internal sealed class DictionaryProperty : IProperty
     }
 
     // Read a single dictionary entry
-    private void ReadEntry(BinaryReader br)
+    private void ReadEntry(BinaryReader br, Encoding encoding)
     {
         uint propertyIdentifier = br.ReadUInt32();
         int length = br.ReadInt32();
@@ -66,7 +69,7 @@ internal sealed class DictionaryProperty : IProperty
         int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
         int nonNullSize = Math.Max(0, nameBytes.Length - nullByteCount);
 
-        string entryName = Encoding.GetEncoding(codePage).GetString(nameBytes, 0, nonNullSize);
+        string entryName = encoding.GetString(nameBytes, 0, nonNullSize);
         entries!.Add(propertyIdentifier, entryName);
     }
 
@@ -83,9 +86,12 @@ internal sealed class DictionaryProperty : IProperty
 
         bw.Write(entries!.Count);
 
+        // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
+        Encoding encoding = Encoding.GetEncoding(codePage);
+
         foreach (KeyValuePair<uint, string> kv in entries)
         {
-            WriteEntry(bw, kv.Key, kv.Value);
+            WriteEntry(bw, kv.Key, kv.Value, encoding);
         }
 
         int size = (int)(bw.BaseStream.Position - curPos);
@@ -93,13 +99,13 @@ internal sealed class DictionaryProperty : IProperty
     }
 
     // Write a single entry to the dictionary, and handle and required null termination and padding.
-    private void WriteEntry(BinaryWriter bw, uint propertyIdentifier, string name)
+    private void WriteEntry(BinaryWriter bw, uint propertyIdentifier, string name, Encoding encoding)
     {
         // Write the PropertyIdentifier
         bw.Write(propertyIdentifier);
 
         // Encode string data with the current code page
-        byte[] nameBytes = Encoding.GetEncoding(codePage).GetBytes(name);
+        byte[] nameBytes = encoding.GetBytes(name);
         uint byteLength = (uint)nameBytes.Length;
 
         // If the code page is WINUNICODE, write the length as the number of characters and pad the length to a multiple of 4 bytes


### PR DESCRIPTION
…once

Instead of once per property.
As there are multiple properties, and all have the same code page, we can call Encoding.GetEncoding once and use it for all the properties, rather than calling GetEncoding per property.

This actually gives a measurable performance increase when reading DocumentSummaryInformation property streams with UserDefined properties.

This was an observation whilst doing https://github.com/openmcdf/openmcdf/pull/420 that I noticed when I changed a Unicode case to always use Encoding.Unicode instead of calling Encoding.GetEncoding and it got faster (GetEncoding appears to do some internal locking that we can skip by only doing it once, at least when all the additional code pages have been registered in PropertyFactory)

I currently get these benchmark results with the main branch:
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.745 us | 0.2486 us | 0.0136 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 6.101 us | 0.0717 us | 0.0039 us | 0.3204 |   5.26 KB |
| ReadWinUnicodeDocumentSummaryInformation | 6.568 us | 0.3831 us | 0.0210 us | 0.3891 |   6.43 KB |
```

But after this change I get
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.729 us | 0.2317 us | 0.0127 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 5.608 us | 0.4978 us | 0.0273 us | 0.3128 |    5.2 KB |
| ReadWinUnicodeDocumentSummaryInformation | 4.630 us | 0.5672 us | 0.0311 us | 0.3738 |   6.18 KB |
```

The Unicode case gets a bigger difference because the test file contains more properties.
Seems worth doing though when it's quite simple.