### PR TITLE
Convert PropertyIdentifierAndOffset to a record struct

### DIFF
--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -253,7 +253,7 @@ public class OlePropertiesContainer
             ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, op.PropertyIdentifier);
             p.Value = op.Value;
             ps.PropertySet0.Properties.Add(p);
-            ps.PropertySet0.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset() { PropertyIdentifier = op.PropertyIdentifier, Offset = 0 });
+            ps.PropertySet0.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
         }
 
         if (UserDefinedProperties is not null)
@@ -277,7 +277,7 @@ public class OlePropertiesContainer
                 ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, op.PropertyIdentifier);
                 p.Value = op.Value;
                 ps.PropertySet1.Properties.Add(p);
-                ps.PropertySet1.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset() { PropertyIdentifier = op.PropertyIdentifier, Offset = 0 });
+                ps.PropertySet1.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
             }
         }
 

--- a/OpenMcdf.Ole/OpenMcdf.Ole.csproj
+++ b/OpenMcdf.Ole/OpenMcdf.Ole.csproj
@@ -28,6 +28,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
+
+    <Compile Include="../OpenMcdf/System/IsExternalInit.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenMcdf.Ole/PropertyIdentifierAndOffset.cs
+++ b/OpenMcdf.Ole/PropertyIdentifierAndOffset.cs
@@ -1,15 +1,12 @@
 ﻿namespace OpenMcdf.Ole;
 
-internal sealed class PropertyIdentifierAndOffset : IBinarySerializable
+internal readonly record struct PropertyIdentifierAndOffset(uint PropertyIdentifier, uint Offset)
 {
-    public uint PropertyIdentifier { get; set; }
-
-    public uint Offset { get; set; }
-
-    public void Read(BinaryReader br)
+    public static PropertyIdentifierAndOffset Read(BinaryReader br)
     {
-        PropertyIdentifier = br.ReadUInt32();
-        Offset = br.ReadUInt32();
+        uint propertyIdentifier = br.ReadUInt32();
+        uint offset = br.ReadUInt32();
+        return new(propertyIdentifier, offset);
     }
 
     public void Write(BinaryWriter bw)

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -21,7 +21,7 @@ internal sealed class PropertySet
             throw new FileFormatException("Required CodePage property not present");
         }
 
-        int codePageOffset = (int)(propertySetOffset + codePageProperty.Offset);
+        int codePageOffset = (int)(propertySetOffset + codePageProperty.Value.Offset);
         br.BaseStream.Seek(codePageOffset, SeekOrigin.Begin);
 
         var vType = (VTPropertyType)br.ReadUInt16();
@@ -32,7 +32,7 @@ internal sealed class PropertySet
         PropertyIdentifierAndOffset? localeProperty = PropertyIdentifierAndOffsets.FirstOrDefault(pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.Locale);
         if (localeProperty is not null)
         {
-            long localeOffset = propertySetOffset + localeProperty.Offset;
+            long localeOffset = propertySetOffset + localeProperty.Value.Offset;
             br.BaseStream.Seek(localeOffset, SeekOrigin.Begin);
 
             vType = (VTPropertyType)br.ReadUInt16();
@@ -50,6 +50,6 @@ internal sealed class PropertySet
             Value = propertyNames,
         };
         Properties.Add(dictionaryProperty);
-        PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset() { PropertyIdentifier = SpecialPropertyIdentifiers.Dictionary, Offset = 0 });
+        PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(SpecialPropertyIdentifiers.Dictionary, 0));
     }
 }

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -68,8 +68,7 @@ internal sealed class PropertySetStream
         // Read property offsets (P0)
         for (int i = 0; i < propertyCount; i++)
         {
-            PropertyIdentifierAndOffset pio = new();
-            pio.Read(br);
+            PropertyIdentifierAndOffset pio = PropertyIdentifierAndOffset.Read(br);
             PropertySet0.PropertyIdentifierAndOffsets.Add(pio);
         }
 
@@ -99,8 +98,7 @@ internal sealed class PropertySetStream
             // Read property offsets
             for (int i = 0; i < propertyCount; i++)
             {
-                PropertyIdentifierAndOffset pio = new();
-                pio.Read(br);
+                PropertyIdentifierAndOffset pio = PropertyIdentifierAndOffset.Read(br);
                 PropertySet1.PropertyIdentifierAndOffsets.Add(pio);
             }
 


### PR DESCRIPTION
Instances are immutable (they're never modified after creation), so being a record seems reasonable and makes things a tad simpler.

Just a little bit of musing on things when testing other changes.

I initially just made it a record to make it immutable, but then ran the benchmarks being a struct does save a little bit of memory - 

Before:
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.703 us | 0.1786 us | 0.0098 us | 0.1869 |   3.07 KB |
| ReadDocumentSummaryInformation           | 5.573 us | 0.3971 us | 0.0218 us | 0.3128 |    5.2 KB |
| ReadWinUnicodeDocumentSummaryInformation | 4.632 us | 0.4080 us | 0.0224 us | 0.3738 |   6.18 KB |
```

After:
```
| Method                                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| ReadSummaryInformation                   | 2.627 us | 0.3772 us | 0.0207 us | 0.1678 |   2.79 KB |
| ReadDocumentSummaryInformation           | 5.670 us | 0.2162 us | 0.0119 us | 0.2899 |    4.8 KB |
| ReadWinUnicodeDocumentSummaryInformation | 4.653 us | 0.4106 us | 0.0225 us | 0.3510 |   5.73 KB |
```

Open for comments on it being a struct or a class. There are similar things in the core library that are structs for reference though.