### PR TITLE
Add UserDefinedProperties to container type conversions

### DIFF
--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -297,6 +297,8 @@ public class OlePropertiesContainer
             return ContainerType.ImageInfo;
         else if (fmtId0 == FormatIdentifiers.ImageContents)
             return ContainerType.ImageContents;
+        else if (fmtId0 == FormatIdentifiers.UserDefinedProperties)
+            return ContainerType.UserDefinedProperties;
 
         return ContainerType.AppSpecific;
     }
@@ -311,6 +313,7 @@ public class OlePropertiesContainer
             ContainerType.GlobalInfo => FormatIdentifiers.GlobalInfo,
             ContainerType.ImageContents => FormatIdentifiers.ImageContents,
             ContainerType.ImageInfo => FormatIdentifiers.ImageInfo,
+            ContainerType.UserDefinedProperties => FormatIdentifiers.UserDefinedProperties,
             _ => FormatIdentifiers.DocSummaryInformation,
         };
     }


### PR DESCRIPTION
…rType

As it stands the reading/writing of the UserDefined property set uses fixed values rather than attention to the mappings, but I think it's worth being consistent here.

This will conflict with #395 but hey ho