### PR TITLE
Move PropertySet reading code from PropertySetStream into PropertySet itself

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -6,7 +6,7 @@ internal sealed class DictionaryProperty(int codePage, Dictionary<uint, string> 
 {
     private Dictionary<uint, string>? entries = entries;
 
-    public PropertyType PropertyType => PropertyType.DictionaryProperty;
+    public Dictionary<uint, string>? Entries => entries;
 
     public object? Value
     {

--- a/OpenMcdf.Ole/IProperty.cs
+++ b/OpenMcdf.Ole/IProperty.cs
@@ -1,14 +1,6 @@
 ﻿namespace OpenMcdf.Ole;
 
-internal enum PropertyType
-{
-    TypedPropertyValue = 0,
-    DictionaryProperty = 1,
-}
-
 internal interface IProperty : IBinarySerializable
 {
     object? Value { get; set; }
-
-    PropertyType PropertyType { get; }
 }

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -244,7 +244,7 @@ public class OlePropertiesContainer
             FMTID1 = Guid.Empty,
             Offset1 = 0,
 
-            PropertySet0 = CreatePropertySet(this.FMTID0, Context, Properties.Count, containerPropertyNames),
+            PropertySet0 = PropertySet.Create(this.FMTID0, Context, Properties.Count, containerPropertyNames),
         };
 
         foreach (OleProperty op in Properties)
@@ -256,7 +256,7 @@ public class OlePropertiesContainer
         {
             ps.NumPropertySets = 2;
             ps.FMTID1 = FormatIdentifiers.UserDefinedProperties;
-            ps.PropertySet1 = CreatePropertySet(ps.FMTID1, UserDefinedProperties.Context, UserDefinedProperties.Properties.Count, UserDefinedProperties.PropertyNames!);
+            ps.PropertySet1 = PropertySet.Create(ps.FMTID1, UserDefinedProperties.Context, UserDefinedProperties.Properties.Count, UserDefinedProperties.PropertyNames!);
             ps.Offset1 = 0;
 
             // Add the properties themselves
@@ -267,16 +267,6 @@ public class OlePropertiesContainer
         }
 
         ps.Write(bw);
-    }
-
-    private static PropertySet CreatePropertySet(in Guid fmtId, PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyNames)
-    {
-        if (fmtId == FormatIdentifiers.DocSummaryInformation)
-            return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
-        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
-            return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
-
-        return new PropertySet(propertyContext, initialPropertyCount, propertyNames);
     }
 
     // Determine the type of the container from the FMTID0 property.

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -61,9 +61,7 @@ public class OlePropertiesContainer
 
         FMTID0 = pStream.FMTID0;
         ContainerType = ContainerTypeFromFmtId(pStream.FMTID0);
-
-        PropertyNames = (Dictionary<uint, string>?)pStream.PropertySet0!.Properties
-            .FirstOrDefault(p => p.PropertyType == PropertyType.DictionaryProperty)?.Value;
+        PropertyNames = pStream.PropertySet0!.DictionaryProperty?.Entries;
 
         Context = pStream.PropertySet0.PropertyContext;
         properties = new(pStream.PropertySet0.Properties.Count);
@@ -119,10 +117,7 @@ public class OlePropertiesContainer
             properties.Add(op);
         }
 
-        var existingPropertyNames = (Dictionary<uint, string>?)propertySet.Properties
-            .FirstOrDefault(p => p.PropertyType == PropertyType.DictionaryProperty)?.Value;
-
-        PropertyNames = existingPropertyNames ?? [];
+        PropertyNames = propertySet.DictionaryProperty?.Entries ?? [];
     }
 
     public IList<OleProperty> Properties => properties;
@@ -245,10 +240,7 @@ public class OlePropertiesContainer
             FMTID1 = Guid.Empty,
             Offset1 = 0,
 
-            PropertySet0 = new PropertySet
-            {
-                PropertyContext = Context,
-            },
+            PropertySet0 = CreatePropertySet(this.FMTID0, Context, Properties.Count),
         };
 
         // If we're writing an AppSpecific property set and have property names, then add a dictionary property
@@ -257,27 +249,16 @@ public class OlePropertiesContainer
             ps.PropertySet0.Add(PropertyNames);
         }
 
-        PropertyFactory factory =
-            ContainerType == ContainerType.DocumentSummaryInfo ? DocumentSummaryInfoPropertyFactory.Default : DefaultPropertyFactory.Default;
-
         foreach (OleProperty op in Properties)
         {
-            ITypedPropertyValue p = factory.CreateProperty(op.VTType, Context.CodePage, op.PropertyIdentifier);
-            p.Value = op.Value;
-            ps.PropertySet0.Properties.Add(p);
-            ps.PropertySet0.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
+            ps.PropertySet0.AddProperty(op.VTType, op.PropertyIdentifier, op.Value);
         }
 
         if (UserDefinedProperties is not null)
         {
             ps.NumPropertySets = 2;
-
-            ps.PropertySet1 = new PropertySet
-            {
-                PropertyContext = UserDefinedProperties.Context,
-            };
-
             ps.FMTID1 = FormatIdentifiers.UserDefinedProperties;
+            ps.PropertySet1 = CreatePropertySet(ps.FMTID1, UserDefinedProperties.Context, UserDefinedProperties.Properties.Count);
             ps.Offset1 = 0;
 
             // Add the dictionary containing the property names
@@ -286,14 +267,21 @@ public class OlePropertiesContainer
             // Add the properties themselves
             foreach (OleProperty op in UserDefinedProperties.Properties)
             {
-                ITypedPropertyValue p = DefaultPropertyFactory.Default.CreateProperty(op.VTType, ps.PropertySet1.PropertyContext.CodePage, op.PropertyIdentifier);
-                p.Value = op.Value;
-                ps.PropertySet1.Properties.Add(p);
-                ps.PropertySet1.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(op.PropertyIdentifier, 0));
+                ps.PropertySet1.AddProperty(op.VTType, op.PropertyIdentifier, op.Value);
             }
         }
 
         ps.Write(bw);
+    }
+
+    private static PropertySet CreatePropertySet(Guid fmtId, PropertyContext propertyContext, int initialPropertyCount)
+    {
+        if (fmtId == FormatIdentifiers.DocSummaryInformation)
+            return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount);
+        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+            return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount);
+
+        return new PropertySet(propertyContext, initialPropertyCount);
     }
 
     // Determine the type of the container from the FMTID0 property.

--- a/OpenMcdf.Ole/OlePropertiesContainer.cs
+++ b/OpenMcdf.Ole/OlePropertiesContainer.cs
@@ -225,6 +225,10 @@ public class OlePropertiesContainer
     {
         using BinaryWriter bw = new(cfStream, Encoding.UTF8, leaveOpen: true);
 
+        // If we're writing an AppSpecific property set and have property names, then add a dictionary property
+        Dictionary<uint, string>? containerPropertyNames =
+            (ContainerType == ContainerType.AppSpecific && PropertyNames is not null && PropertyNames.Count > 0) ? PropertyNames : null;
+
         PropertySetStream ps = new()
         {
             ByteOrder = 0xFFFE,
@@ -240,14 +244,8 @@ public class OlePropertiesContainer
             FMTID1 = Guid.Empty,
             Offset1 = 0,
 
-            PropertySet0 = CreatePropertySet(this.FMTID0, Context, Properties.Count),
+            PropertySet0 = CreatePropertySet(this.FMTID0, Context, Properties.Count, containerPropertyNames),
         };
-
-        // If we're writing an AppSpecific property set and have property names, then add a dictionary property
-        if (ContainerType == ContainerType.AppSpecific && PropertyNames is not null && PropertyNames.Count > 0)
-        {
-            ps.PropertySet0.Add(PropertyNames);
-        }
 
         foreach (OleProperty op in Properties)
         {
@@ -258,11 +256,8 @@ public class OlePropertiesContainer
         {
             ps.NumPropertySets = 2;
             ps.FMTID1 = FormatIdentifiers.UserDefinedProperties;
-            ps.PropertySet1 = CreatePropertySet(ps.FMTID1, UserDefinedProperties.Context, UserDefinedProperties.Properties.Count);
+            ps.PropertySet1 = CreatePropertySet(ps.FMTID1, UserDefinedProperties.Context, UserDefinedProperties.Properties.Count, UserDefinedProperties.PropertyNames!);
             ps.Offset1 = 0;
-
-            // Add the dictionary containing the property names
-            ps.PropertySet1.Add(UserDefinedProperties.PropertyNames!);
 
             // Add the properties themselves
             foreach (OleProperty op in UserDefinedProperties.Properties)
@@ -274,14 +269,14 @@ public class OlePropertiesContainer
         ps.Write(bw);
     }
 
-    private static PropertySet CreatePropertySet(Guid fmtId, PropertyContext propertyContext, int initialPropertyCount)
+    private static PropertySet CreatePropertySet(in Guid fmtId, PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyNames)
     {
         if (fmtId == FormatIdentifiers.DocSummaryInformation)
-            return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount);
+            return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
         else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
-            return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount);
+            return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
 
-        return new PropertySet(propertyContext, initialPropertyCount);
+        return new PropertySet(propertyContext, initialPropertyCount, propertyNames);
     }
 
     // Determine the type of the container from the FMTID0 property.

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -41,6 +41,9 @@ internal class PropertySet
             br.BaseStream.Seek(propertySetOffset + propertyIdentifierAndOffset.Offset, SeekOrigin.Begin);
             IProperty property = ReadProperty(propertyIdentifierAndOffset.PropertyIdentifier, this.PropertyContext.CodePage, br);
             this.Properties.Add(property);
+
+            if (property is DictionaryProperty dictionaryProperty)
+                this.DictionaryProperty = dictionaryProperty;
         }
 
         // Load additional context properties
@@ -112,13 +115,9 @@ internal class PropertySet
     // Note: This is virtual so that the behavior can be overridden in specific property sets
     protected virtual IProperty ReadProperty(uint propertyIdentifier, int codePage, BinaryReader br)
     {
-        if (propertyIdentifier == SpecialPropertyIdentifiers.Dictionary)
-        {
-            this.DictionaryProperty = DictionaryProperty.Read(br, codePage);
-            return this.DictionaryProperty;
-        }
-
-        return ReadTypedProperty(propertyIdentifier, codePage, br);
+        return propertyIdentifier == SpecialPropertyIdentifiers.Dictionary
+            ? DictionaryProperty.Read(br, codePage)
+            : ReadTypedProperty(propertyIdentifier, codePage, br);
     }
 
     // Read the specified typed property value

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -68,7 +68,8 @@ internal class PropertySet
     {
         if (fmtId == FormatIdentifiers.DocSummaryInformation)
             return new DocumentSummaryInformationPropertySet(br, propertySetOffset);
-        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+
+        if (fmtId == FormatIdentifiers.HwpSummaryInformation)
             return new HwpSummaryInformationPropertySet(br, propertySetOffset);
 
         return new PropertySet(br, propertySetOffset);
@@ -78,7 +79,8 @@ internal class PropertySet
     {
         if (fmtId == FormatIdentifiers.DocSummaryInformation)
             return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
-        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+
+        if (fmtId == FormatIdentifiers.HwpSummaryInformation)
             return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
 
         return new PropertySet(propertyContext, initialPropertyCount, propertyNames);

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -64,6 +64,26 @@ internal class PropertySet
         }
     }
 
+    public static PropertySet Read(in Guid fmtId, BinaryReader br, uint propertySetOffset)
+    {
+        if (fmtId == FormatIdentifiers.DocSummaryInformation)
+            return new DocumentSummaryInformationPropertySet(br, propertySetOffset);
+        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+            return new HwpSummaryInformationPropertySet(br, propertySetOffset);
+
+        return new PropertySet(br, propertySetOffset);
+    }
+
+    public static PropertySet Create(in Guid fmtId, PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyNames)
+    {
+        if (fmtId == FormatIdentifiers.DocSummaryInformation)
+            return new DocumentSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
+        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+            return new HwpSummaryInformationPropertySet(propertyContext, initialPropertyCount, propertyNames);
+
+        return new PropertySet(propertyContext, initialPropertyCount, propertyNames);
+    }
+
     // ReadCodePage is virtual to allow PropertySet specific handling of missing/default values
     protected virtual int ReadCodePage(BinaryReader br, uint propertySetOffset)
     {

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -12,7 +12,7 @@ internal class PropertySet
 
     protected virtual PropertyFactory PropertyFactory { get; } = DefaultPropertyFactory.Default;
 
-    public DictionaryProperty? DictionaryProperty { get; private set; }
+    public DictionaryProperty? DictionaryProperty { get; }
 
     // Create a PropertySet by reading from the supplied BinaryReader
     public PropertySet(BinaryReader br, uint propertySetOffset)
@@ -50,11 +50,18 @@ internal class PropertySet
         LoadContext();
     }
 
-    public PropertySet(PropertyContext propertyContext, int initialPropertyCount)
+    public PropertySet(PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyNames)
     {
         this.PropertyContext = propertyContext;
         this.PropertyIdentifierAndOffsets = new(initialPropertyCount);
         this.Properties = new(initialPropertyCount);
+
+        if (propertyNames is not null)
+        {
+            this.DictionaryProperty = new(PropertyContext.CodePage, propertyNames);
+            Properties.Add(this.DictionaryProperty);
+            PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(SpecialPropertyIdentifiers.Dictionary, 0));
+        }
     }
 
     // ReadCodePage is virtual to allow PropertySet specific handling of missing/default values
@@ -96,13 +103,6 @@ internal class PropertySet
         }
     }
 
-    public void Add(Dictionary<uint, string> propertyNames)
-    {
-        this.DictionaryProperty = new(PropertyContext.CodePage, propertyNames);
-        Properties.Add(this.DictionaryProperty);
-        PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(SpecialPropertyIdentifiers.Dictionary, 0));
-    }
-
     public void AddProperty(VTPropertyType vType, uint propertyIdentifier, object? value)
     {
         ITypedPropertyValue p = this.PropertyFactory.CreateProperty(vType, PropertyContext.CodePage, propertyIdentifier);
@@ -138,8 +138,8 @@ internal sealed class DocumentSummaryInformationPropertySet : PropertySet
     {
     }
 
-    public DocumentSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount)
-        : base(propertyContext, initialPropertyCount)
+    public DocumentSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyName)
+        : base(propertyContext, initialPropertyCount, propertyName)
     {
     }
 
@@ -154,8 +154,8 @@ internal sealed class HwpSummaryInformationPropertySet : PropertySet
     {
     }
 
-    public HwpSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount)
-        : base(propertyContext, initialPropertyCount)
+    public HwpSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount, Dictionary<uint, string>? propertyNames)
+        : base(propertyContext, initialPropertyCount, propertyNames)
     {
     }
 

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -1,54 +1,169 @@
 ﻿namespace OpenMcdf.Ole;
 
-internal sealed class PropertySet
+internal class PropertySet
 {
-    public PropertyContext PropertyContext { get; set; } = new();
+    public PropertyContext PropertyContext { get; } = new();
 
     public uint Size { get; set; }
 
-    public List<PropertyIdentifierAndOffset> PropertyIdentifierAndOffsets { get; } = new();
+    public List<PropertyIdentifierAndOffset> PropertyIdentifierAndOffsets { get; }
 
-    public List<IProperty> Properties { get; } = new();
+    public List<IProperty> Properties { get; }
 
-    public void LoadContext(int propertySetOffset, BinaryReader br)
+    protected virtual PropertyFactory PropertyFactory { get; } = DefaultPropertyFactory.Default;
+
+    public DictionaryProperty? DictionaryProperty { get; private set; }
+
+    // Create a PropertySet by reading from the supplied BinaryReader
+    public PropertySet(BinaryReader br, uint propertySetOffset)
     {
-        long currPos = br.BaseStream.Position;
+        this.Size = br.ReadUInt32();
 
-        // Read the code page - this should always be present
+        uint propertyCount = br.ReadUInt32();
+
+        // Read property offsets
+        // When reserving space in the collection, clamp the size in case it's a corrupt (i.e. huge) value. Value picked based on the number of properties in common property sets.
+        this.PropertyIdentifierAndOffsets = new((int)Math.Min(propertyCount, 28));
+        for (int i = 0; i < propertyCount; i++)
+        {
+            PropertyIdentifierAndOffset pio = PropertyIdentifierAndOffset.Read(br);
+            PropertyIdentifierAndOffsets.Add(pio);
+        }
+
+        // Treat the code page property specially - we need it to read all the code page specific properties.
+        this.PropertyContext.CodePage = ReadCodePage(br, propertySetOffset);
+
+        // Read properties
+        this.Properties = new(this.PropertyIdentifierAndOffsets.Count);
+        for (int i = 0; i < propertyCount; i++)
+        {
+            PropertyIdentifierAndOffset propertyIdentifierAndOffset = this.PropertyIdentifierAndOffsets[i];
+            br.BaseStream.Seek(propertySetOffset + propertyIdentifierAndOffset.Offset, SeekOrigin.Begin);
+            IProperty property = ReadProperty(propertyIdentifierAndOffset.PropertyIdentifier, this.PropertyContext.CodePage, br);
+            this.Properties.Add(property);
+        }
+
+        // Load additional context properties
+        LoadContext();
+    }
+
+    public PropertySet(PropertyContext propertyContext, int initialPropertyCount)
+    {
+        this.PropertyContext = propertyContext;
+        this.PropertyIdentifierAndOffsets = new(initialPropertyCount);
+        this.Properties = new(initialPropertyCount);
+    }
+
+    // ReadCodePage is virtual to allow PropertySet specific handling of missing/default values
+    protected virtual int ReadCodePage(BinaryReader br, uint propertySetOffset)
+    {
+        int? propertySetCodePage = TryReadCodePage(br, propertySetOffset);
+        return propertySetCodePage ?? throw new FileFormatException("Required CodePage property not present.");
+    }
+
+    protected int? TryReadCodePage(BinaryReader br, uint propertySetOffset)
+    {
         int codePagePropertyIndex = PropertyIdentifierAndOffsets.FindIndex(static pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.CodePage);
         if (codePagePropertyIndex == -1)
         {
-            throw new FileFormatException("Required CodePage property not present.");
+            return null;
         }
 
-        PropertyIdentifierAndOffset codePageProperty = PropertyIdentifierAndOffsets[codePagePropertyIndex];
-        long codePageOffset = propertySetOffset + codePageProperty.Offset;
+        long codePageOffset = propertySetOffset + PropertyIdentifierAndOffsets[codePagePropertyIndex].Offset;
         br.BaseStream.Seek(codePageOffset, SeekOrigin.Begin);
 
         var vType = (VTPropertyType)br.ReadUInt16();
         br.ReadUInt16(); // Ushort Padding
-        PropertyContext.CodePage = (ushort)br.ReadInt16();
 
+        return (ushort)br.ReadInt16();
+    }
+
+    // Populate additional context properties, if present
+    private void LoadContext()
+    {
         // Read the Locale, if present
         int localePropertyIndex = PropertyIdentifierAndOffsets.FindIndex(static pio => pio.PropertyIdentifier == SpecialPropertyIdentifiers.Locale);
         if (localePropertyIndex != -1)
         {
-            PropertyIdentifierAndOffset localeProperty = PropertyIdentifierAndOffsets[localePropertyIndex];
-            long localeOffset = propertySetOffset + localeProperty.Offset;
-            br.BaseStream.Seek(localeOffset, SeekOrigin.Begin);
-
-            vType = (VTPropertyType)br.ReadUInt16();
-            br.ReadUInt16(); // Ushort Padding
-            PropertyContext.Locale = br.ReadUInt32();
+            IProperty localeProperty = Properties[localePropertyIndex];
+            if (localeProperty is ITypedPropertyValue { VTType: VTPropertyType.VT_UI4, Value: uint uintLocaleValue })
+            {
+                this.PropertyContext.Locale = uintLocaleValue;
+            }
         }
-
-        br.BaseStream.Position = currPos;
     }
 
     public void Add(Dictionary<uint, string> propertyNames)
     {
-        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage, propertyNames);
-        Properties.Add(dictionaryProperty);
+        this.DictionaryProperty = new(PropertyContext.CodePage, propertyNames);
+        Properties.Add(this.DictionaryProperty);
         PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(SpecialPropertyIdentifiers.Dictionary, 0));
     }
+
+    public void AddProperty(VTPropertyType vType, uint propertyIdentifier, object? value)
+    {
+        ITypedPropertyValue p = this.PropertyFactory.CreateProperty(vType, PropertyContext.CodePage, propertyIdentifier);
+        p.Value = value;
+        this.Properties.Add(p);
+        this.PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(propertyIdentifier, 0));
+    }
+
+    // Read a given property, special casing the dictionary property.
+    // Note: This is virtual so that the behavior can be overridden in specific property sets
+    protected virtual IProperty ReadProperty(uint propertyIdentifier, int codePage, BinaryReader br)
+    {
+        if (propertyIdentifier == SpecialPropertyIdentifiers.Dictionary)
+        {
+            this.DictionaryProperty = DictionaryProperty.Read(br, codePage);
+            return this.DictionaryProperty;
+        }
+
+        return ReadTypedProperty(propertyIdentifier, codePage, br);
+    }
+
+    // Read the specified typed property value
+    protected ITypedPropertyValue ReadTypedProperty(uint propertyIdentifier, int codePage, BinaryReader br)
+    {
+        var vType = (VTPropertyType)br.ReadUInt16();
+        br.ReadUInt16(); // Ushort Padding
+
+        return this.PropertyFactory.ReadProperty(br, vType, codePage, propertyIdentifier);
+    }
+}
+
+// Specific handling for the DocumentSummaryInformation property set - it has special handling for some unaligned strings
+internal sealed class DocumentSummaryInformationPropertySet : PropertySet
+{
+    public DocumentSummaryInformationPropertySet(BinaryReader br, uint propertySetOffset)
+        : base(br, propertySetOffset)
+    {
+    }
+
+    public DocumentSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount)
+        : base(propertyContext, initialPropertyCount)
+    {
+    }
+
+    protected override PropertyFactory PropertyFactory { get; } = DocumentSummaryInfoPropertyFactory.Default;
+}
+
+// Specific handling for the HwpSummaryInformation property set - It doesn't usually contain a codePage property and there is a property with an id of 0 that isn't a dictionary.
+internal sealed class HwpSummaryInformationPropertySet : PropertySet
+{
+    public HwpSummaryInformationPropertySet(BinaryReader br, uint propertySetOffset)
+        : base(br, propertySetOffset)
+    {
+    }
+
+    public HwpSummaryInformationPropertySet(PropertyContext propertyContext, int initialPropertyCount)
+        : base(propertyContext, initialPropertyCount)
+    {
+    }
+
+    // The 'HwpSummaryInformation' stream doesn't have to contain a code page, treat the default codepage as UTF-8
+    // NOTE: This is what various other HWP readers do, but it needs more test files to confirm - it's common to use VT_LPWSTR properties which are always CP_WINUNICODE
+    protected override int ReadCodePage(BinaryReader br, uint propertySetOffset) => TryReadCodePage(br, propertySetOffset) ?? 65001;
+
+    // Only support typed properties here, don't try to handle dictionary properties.
+    protected override IProperty ReadProperty(uint propertyIdentifier, int codePage, BinaryReader br) => ReadTypedProperty(propertyIdentifier, codePage, br);
 }

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -163,7 +163,7 @@ internal sealed class PropertySetStream
         }
     }
 
-    private static PropertySet ReadPropertySet(Guid fmtId, BinaryReader br, uint propertySetOffset)
+    private static PropertySet ReadPropertySet(in Guid fmtId, BinaryReader br, uint propertySetOffset)
     {
         if (fmtId == FormatIdentifiers.DocSummaryInformation)
             return new DocumentSummaryInformationPropertySet(br, propertySetOffset);

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -33,10 +33,6 @@ internal sealed class PropertySetStream
 
     public PropertySet? PropertySet1 { get; set; }
 
-    public PropertySetStream()
-    {
-    }
-
     public void Read(BinaryReader br)
     {
         br.BaseStream.Position = 0;
@@ -55,63 +51,12 @@ internal sealed class PropertySetStream
             Offset1 = br.ReadUInt32();
         }
 
-        uint size = br.ReadUInt32();
-        uint propertyCount = br.ReadUInt32();
-        PropertySet0 = new PropertySet
-        {
-            Size = size,
-        };
-
-        // Create appropriate property factory based on the stream type
-        PropertyFactory factory = FMTID0 == FormatIdentifiers.DocSummaryInformation ? DocumentSummaryInfoPropertyFactory.Default : DefaultPropertyFactory.Default;
-
-        // Read property offsets (P0)
-        for (int i = 0; i < propertyCount; i++)
-        {
-            PropertyIdentifierAndOffset pio = PropertyIdentifierAndOffset.Read(br);
-            PropertySet0.PropertyIdentifierAndOffsets.Add(pio);
-        }
-
-        PropertySet0.LoadContext((int)Offset0, br);  // Read CodePage, Locale
-
-        // Read properties (P0)
-        for (int i = 0; i < propertyCount; i++)
-        {
-            PropertyIdentifierAndOffset propertyIdentifierAndOffset = PropertySet0.PropertyIdentifierAndOffsets[i];
-            br.BaseStream.Seek(Offset0 + propertyIdentifierAndOffset.Offset, SeekOrigin.Begin);
-            IProperty property = ReadProperty(propertyIdentifierAndOffset.PropertyIdentifier, PropertySet0.PropertyContext.CodePage, br, factory);
-            PropertySet0.Properties.Add(property);
-        }
+        PropertySet0 = ReadPropertySet(FMTID0, br, Offset0);
 
         if (NumPropertySets == 2)
         {
             br.BaseStream.Seek(Offset1, SeekOrigin.Begin);
-
-            size = br.ReadUInt32();
-            propertyCount = br.ReadUInt32();
-
-            PropertySet1 = new PropertySet
-            {
-                Size = size,
-            };
-
-            // Read property offsets
-            for (int i = 0; i < propertyCount; i++)
-            {
-                PropertyIdentifierAndOffset pio = PropertyIdentifierAndOffset.Read(br);
-                PropertySet1.PropertyIdentifierAndOffsets.Add(pio);
-            }
-
-            PropertySet1.LoadContext((int)Offset1, br);
-
-            // Read properties
-            for (int i = 0; i < propertyCount; i++)
-            {
-                PropertyIdentifierAndOffset idAndOffset = PropertySet1.PropertyIdentifierAndOffsets[i];
-                br.BaseStream.Seek(Offset1 + idAndOffset.Offset, SeekOrigin.Begin);
-                IProperty property = ReadProperty(idAndOffset.PropertyIdentifier, PropertySet1.PropertyContext.CodePage, br, DefaultPropertyFactory.Default);
-                PropertySet1.Properties.Add(property);
-            }
+            PropertySet1 = ReadPropertySet(FMTID1, br, Offset1);
         }
     }
 
@@ -218,17 +163,14 @@ internal sealed class PropertySetStream
         }
     }
 
-    private static IProperty ReadProperty(uint propertyIdentifier, int codePage, BinaryReader br, PropertyFactory factory)
+    private static PropertySet ReadPropertySet(Guid fmtId, BinaryReader br, uint propertySetOffset)
     {
-        if (propertyIdentifier == SpecialPropertyIdentifiers.Dictionary)
-        {
-            return DictionaryProperty.Read(br, codePage);
-        }
+        if (fmtId == FormatIdentifiers.DocSummaryInformation)
+            return new DocumentSummaryInformationPropertySet(br, propertySetOffset);
+        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
+            return new HwpSummaryInformationPropertySet(br, propertySetOffset);
 
-        var vType = (VTPropertyType)br.ReadUInt16();
-        br.ReadUInt16(); // Ushort Padding
-
-        return factory.ReadProperty(br, vType, codePage, propertyIdentifier);
+        return new PropertySet(br, propertySetOffset);
     }
 
     private static void WriteGuid(BinaryWriter writer, in Guid value)

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -51,12 +51,12 @@ internal sealed class PropertySetStream
             Offset1 = br.ReadUInt32();
         }
 
-        PropertySet0 = ReadPropertySet(FMTID0, br, Offset0);
+        PropertySet0 = PropertySet.Read(FMTID0, br, Offset0);
 
         if (NumPropertySets == 2)
         {
             br.BaseStream.Seek(Offset1, SeekOrigin.Begin);
-            PropertySet1 = ReadPropertySet(FMTID1, br, Offset1);
+            PropertySet1 = PropertySet.Read(FMTID1, br, Offset1);
         }
     }
 
@@ -161,16 +161,6 @@ internal sealed class PropertySetStream
                 bw.Write((int)(oc1.PropertyOffsets[i] - oc1.OffsetPS));
             }
         }
-    }
-
-    private static PropertySet ReadPropertySet(in Guid fmtId, BinaryReader br, uint propertySetOffset)
-    {
-        if (fmtId == FormatIdentifiers.DocSummaryInformation)
-            return new DocumentSummaryInformationPropertySet(br, propertySetOffset);
-        else if (fmtId == FormatIdentifiers.HwpSummaryInformation)
-            return new HwpSummaryInformationPropertySet(br, propertySetOffset);
-
-        return new PropertySet(br, propertySetOffset);
     }
 
     private static void WriteGuid(BinaryWriter writer, in Guid value)

--- a/OpenMcdf.Ole/TypedPropertyValue.cs
+++ b/OpenMcdf.Ole/TypedPropertyValue.cs
@@ -7,8 +7,6 @@ internal abstract class TypedPropertyValue<T> : ITypedPropertyValue
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "TODO")]
     protected object? propertyValue;
 
-    public PropertyType PropertyType => PropertyType.TypedPropertyValue;
-
     public VTPropertyType VTType => vtType;
 
     public TypedPropertyValue(VTPropertyType vtType, bool isVariant = false)


### PR DESCRIPTION
I was having a look at this yesterday to try fixing a few issues, adding more HWP support, and some trivial optimizations, and it spiraled off a bit, so here's a WIP for the record.

Basic idea:

- Rework PropertySet so that it can be subclassed to handle differeng behavior between different property sets.
- Change the PropertyFactory logic so that all the usages are internal to PropertySet and the type of factory is determined by the set instead of via separate logic. PropertySetStream and OlePropertiesContainer don't care about the factory any more.
- Move the property set reading logic from PropertySetStream into PropertySet, and remove duplication where PropertySetStream used to have two copies of the same code for reading the first and second property sets.
- Made the DictionaryProperty directly accessible from the PropertySet, and removed the OlePropertiesContainer code that got it by casting other things to a Dictionary
- Add handling for HWP property sets to fix the issue described at https://github.com/openmcdf/openmcdf/issues/394#issuecomment-4370055258
- Picks up the codepage change for HWP property sets from https://github.com/openmcdf/openmcdf/pull/407 in a more self contained way.