### PR TITLE
[WIP] Investigate some shared string reader/writer helper functions

### DIFF
--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -32,7 +32,7 @@ internal static class BinaryReaderExtensions
             return string.Empty;
         }
 
-         // Read the data
+        // Read the data
         byte[] stringBytes = target.ReadBytes(byteLength);
 
         // Skip the null terminator and convert the rest of the data

--- a/OpenMcdf.Ole/BinaryReaderExtensions.cs
+++ b/OpenMcdf.Ole/BinaryReaderExtensions.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace OpenMcdf.Ole;
+
+internal static class BinaryReaderExtensions
+{
+    // Read a CodePage string
+    // This is a string whose length is specified as a number of bytes, and which is encoded in a specified codepage.
+    // The CodePage *might* be CP_WINUNICODE, because LPWSTR properties have to be WINUNICODE, but WINUNICODE properties don't technically *have* to be LPWSTR
+    public static string ReadCodePageString(this BinaryReader target, Encoding encoding)
+    {
+        // Read the length of the string, as a number of bytes.
+        int byteLength = (int)target.ReadUInt32();
+        return target.ReadStringWithEncoding(byteLength, encoding);
+    }
+
+    // Read an LPWSTR type property
+    // This is a string which is encoded in the CP_WINUNICODE codepage and whose length is specific as a number of 2-byte characters.
+    public static string ReadLpwstr(this BinaryReader target)
+    {
+        int nChars = (int)target.ReadUInt32();
+
+        // The length is specified as a number of 2-byte characters, so the number of bytes to read is twice that.
+        return target.ReadStringWithEncoding(nChars * 2, Encoding.Unicode);
+    }
+
+    // Common Implementation of the above 2 functions, just working off byte lengths and the specified encoding
+    private static string ReadStringWithEncoding(this BinaryReader target, int byteLength, Encoding encoding)
+    {
+        if (byteLength == 0)
+        {
+            return string.Empty;
+        }
+
+         // Read the data
+        byte[] stringBytes = target.ReadBytes(byteLength);
+
+        // Skip the null terminator and convert the rest of the data
+        int nullByteCount = encoding.CodePage == CodePages.WinUnicode ? 2 : 1;
+        int nonNullSize = Math.Max(0, stringBytes.Length - nullByteCount);
+
+        return encoding.GetString(stringBytes, 0, nonNullSize);
+    }
+}

--- a/OpenMcdf.Ole/BinaryWriterExtensions.cs
+++ b/OpenMcdf.Ole/BinaryWriterExtensions.cs
@@ -1,0 +1,48 @@
+using System.Text;
+
+namespace OpenMcdf.Ole;
+
+internal static class BinaryWriterExtensions
+{
+    // Write a CodePage string
+    // This is a string whose length is specified as a number of bytes, and which is encoded in a specified codepage.
+    // The CodePage *might* be CP_WINUNICODE, because LPWSTR properties have to be WINUNICODE, but WINUNICODE properties don't technically *have* to be LPWSTR
+    public static void WriteCodePageString(this BinaryWriter target, string value, Encoding encoding) => target.WriteStringCore(value, encoding, false);
+
+    // Write an LPWSTR type property
+    // This is a string which is encoded in the CP_WINUNICODE codepage and whose length is specific as a number of 2-byte characters.
+    public static void WriteLpwstr(this BinaryWriter target, string value) => target.WriteStringCore(value, Encoding.Unicode, true);
+
+    // Shared implementation for the above two functions
+    // 'writeCharLength' is because there are some contexts where the written length is the number of bytes, and some where its the number of characters
+    private static void WriteStringCore(this BinaryWriter target, string value, Encoding encoding, bool writeCharLength)
+    {
+        // If the string is empty, write a length of zero and do no more
+        if (string.IsNullOrEmpty(value))
+        {
+            target.Write(0U);
+        }
+        else
+        {
+            // Encode string data with the current code page
+            int codePage = encoding.CodePage;
+            byte[] valueBytes = encoding.GetBytes(value);
+            uint byteLength = (uint)valueBytes.Length;
+
+            // Add the number of null terminator bytes - two for CP_WINUNICODE strings, 1 otherwise
+            byteLength += codePage == CodePages.WinUnicode ? 2u : 1u;
+
+            // Write either number of bytes or number of two byte characters
+            target.Write(writeCharLength ? (byteLength / 2) : byteLength);
+            target.Write(valueBytes);
+
+            // Write two null bytes for Unicode strings, 1 otherwise
+            target.Write((byte)0);
+
+            if (codePage == CodePages.WinUnicode)
+            {
+                target.Write((byte)0);
+            }
+        }
+    }
+}

--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -34,42 +34,24 @@ internal sealed class DictionaryProperty : IProperty
             ReadEntry(br, encoding);
         }
 
-        int m = (int)(br.BaseStream.Position - curPos) % 4;
-
-        if (m > 0)
-        {
-            for (int i = 0; i < m; i++)
-            {
-                br.ReadByte();
-            }
-        }
+        SkipPadding(br, curPos);
     }
 
     // Read a single dictionary entry
     private void ReadEntry(BinaryReader br, Encoding encoding)
     {
         uint propertyIdentifier = br.ReadUInt32();
-        int length = br.ReadInt32();
 
-        byte[] nameBytes;
+        long curPos = br.BaseStream.Position;
 
-        if (codePage == CodePages.WinUnicode)
+        string entryName = encoding.CodePage == CodePages.WinUnicode ? br.ReadLpwstr() : br.ReadCodePageString(encoding);
+
+        // WinUnicode strings are padded and we have to skip the padding. Other encodings are unpadded.
+        if (encoding.CodePage == CodePages.WinUnicode)
         {
-            nameBytes = br.ReadBytes(length << 1);
-
-            int m = length * 2 % 4;
-            if (m > 0)
-                br.ReadBytes(m);
-        }
-        else
-        {
-            nameBytes = br.ReadBytes(length);
+            SkipPadding(br, curPos);
         }
 
-        int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
-        int nonNullSize = Math.Max(0, nameBytes.Length - nullByteCount);
-
-        string entryName = encoding.GetString(nameBytes, 0, nonNullSize);
         entries!.Add(propertyIdentifier, entryName);
     }
 
@@ -104,32 +86,20 @@ internal sealed class DictionaryProperty : IProperty
         // Write the PropertyIdentifier
         bw.Write(propertyIdentifier);
 
-        // Encode string data with the current code page
-        byte[] nameBytes = encoding.GetBytes(name);
-        uint byteLength = (uint)nameBytes.Length;
-
         // If the code page is WINUNICODE, write the length as the number of characters and pad the length to a multiple of 4 bytes
         // Otherwise, write the length as the number of bytes and don't pad.
-        // In either case, the string must be null terminated
         if (codePage == CodePages.WinUnicode)
         {
-            // Two bytes padding for Unicode strings
-            byteLength += 2;
+            long curPos = bw.BaseStream.Position;
 
-            bw.Write(byteLength / 2);
-            bw.Write(nameBytes);
-            bw.Write((byte)0);
-            bw.Write((byte)0);
+            bw.WriteLpwstr(name);
 
-            WritePaddingIfNeeded(bw, (int)byteLength);
+            int size = (int)(bw.BaseStream.Position - curPos);
+            WritePaddingIfNeeded(bw, size);
         }
         else
         {
-            byteLength += 1;
-
-            bw.Write(byteLength);
-            bw.Write(nameBytes);
-            bw.Write((byte)0);
+            bw.WriteCodePageString(name, encoding);
         }
     }
 
@@ -142,6 +112,20 @@ internal sealed class DictionaryProperty : IProperty
         {
             for (int i = 0; i < 4 - m; i++) // padding
                 bw.Write((byte)0);
+        }
+    }
+
+    // Skip padding up to the 4 byte alignment, if needed
+    private static void SkipPadding(BinaryReader br, long startPos)
+    {
+        int m = (int)(br.BaseStream.Position - startPos) % 4;
+
+        if (m > 0)
+        {
+            for (int i = 0; i < m; i++)
+            {
+                br.ReadByte();
+            }
         }
     }
 }

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -309,70 +309,9 @@ internal abstract class PropertyFactory
             this.codePage = codePage;
         }
 
-        public override string ReadScalarValue(BinaryReader br)
-        {
-            int size = (int)br.ReadUInt32();
-            byte[] data = br.ReadBytes(size);
-            int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
-            int nonNullSize = Math.Max(0, size - nullByteCount);
-            string result = Encoding.GetEncoding(codePage).GetString(data, 0, nonNullSize);
-            return result;
-        }
+        public override string ReadScalarValue(BinaryReader br) => br.ReadCodePageString(Encoding.GetEncoding(codePage));
 
-        public override void WriteScalarValue(BinaryWriter bw, string pValue)
-        {
-            // bool addNullTerminator = true;
-            if (string.IsNullOrEmpty(pValue)) // || String.IsNullOrEmpty(pValue.Trim(new char[] { '\0' })))
-            {
-                bw.Write(0U);
-            }
-            else if (codePage == CodePages.WinUnicode)
-            {
-                byte[] data = Encoding.GetEncoding(codePage).GetBytes(pValue);
-
-                // if (data.Length >= 2 && data[data.Length - 2] == '\0' && data[data.Length - 1] == '\0')
-                //    addNullTerminator = false;
-                uint dataLength = (uint)data.Length;
-
-                // if (addNullTerminator)
-                dataLength += 2;            // null terminator \u+0000
-
-                // var mod = dataLength % 4;       // pad to multiple of 4 bytes
-                bw.Write(dataLength);           // data length of string + null char (unicode)
-                bw.Write(data);                 // string
-
-                // if (addNullTerminator)
-                // {
-                bw.Write('\0');                 // first byte of null unicode char
-                bw.Write('\0');                 // second byte of null unicode char
-                // }
-
-                // for (int i = 0; i < (4 - mod); i++)   // padding
-                //    bw.Write('\0');
-            }
-            else
-            {
-                byte[] data = Encoding.GetEncoding(codePage).GetBytes(pValue);
-
-                // if (data.Length >= 1 && data[data.Length - 1] == '\0')
-                //    addNullTerminator = false;
-                uint dataLength = (uint)data.Length;
-
-                // if (addNullTerminator)
-                dataLength += 1;            // null terminator \u+0000
-
-                bw.Write(dataLength);           // data length of string + null char (unicode)
-                bw.Write(data);                 // string
-
-                // if (addNullTerminator)
-                // {
-                bw.Write('\0');                 // null terminator'\0'
-                // }
-
-                // for (int i = 0; i < (4 - mod); i++)   // padding
-                //    bw.Write('\0');
-            }
-        }
+        public override void WriteScalarValue(BinaryWriter bw, string pValue) => bw.WriteCodePageString(pValue, Encoding.GetEncoding(codePage));
     }
 
     protected sealed class VT_Unaligned_LPSTR_Property : VT_LPSTR_Property
@@ -391,52 +330,9 @@ internal abstract class PropertyFactory
         {
         }
 
-        public override string ReadScalarValue(BinaryReader br)
-        {
-            uint nChars = br.ReadUInt32();
-            string result;
-            if (nChars > 0)
-            {
-                byte[] data = br.ReadBytes((int)((nChars - 1) * 2));  // WChar- null terminator
-                br.ReadBytes(2); // Skip null terminator
-                result = Encoding.Unicode.GetString(data);
-            }
-            else
-            {
-                result = string.Empty;
-            }
+        public override string ReadScalarValue(BinaryReader br) => br.ReadLpwstr();
 
-            // result = result.Trim(new char[] { '\0' });
-            return result;
-        }
-
-        public override void WriteScalarValue(BinaryWriter bw, string pValue)
-        {
-            byte[] data = Encoding.Unicode.GetBytes(pValue);
-
-            // The written data length field is the number of characters (not bytes) and must include a null terminator
-            // add a null terminator if there isn't one already
-            int byteLength = data.Length;
-
-            // bool addNullTerminator =
-            //    byteLength == 0 || data[byteLength - 1] != '\0' || data[byteLength - 2] != '\0';
-
-            // if (addNullTerminator)
-            byteLength += 2;
-
-            bw.Write((uint)byteLength / 2);
-            bw.Write(data);
-
-            // if (addNullTerminator)
-            // {
-            bw.Write((byte)0);
-            bw.Write((byte)0);
-            // }
-
-            // var mod = byteLength % 4;       // pad to multiple of 4 bytes
-            // for (int i = 0; i < (4 - mod); i++)   // padding
-            //    bw.Write('\0');
-        }
+        public override void WriteScalarValue(BinaryWriter bw, string pValue) => bw.WriteLpwstr(pValue);
     }
 
     private sealed class VT_FILETIME_Property : TypedPropertyValue<DateTime>


### PR DESCRIPTION
Just musing on comments in https://github.com/openmcdf/openmcdf/pull/420 about some shared functions. This is just moving things about, it doesn't contain any of the other changes (ReadExactly, stackalloc, etc)

There are two functions for each of read/write due to the differing behaviors of the length being specified as bytes or characters in different places (LPWSTR properties and 'Unicode' dictionary entries always use the char length, LPSTR properties use the byte length even if the code page is WINUNICODE).

Even so, we can hopefully remove some duplication from the property value and dictionary handling.