### PR TITLE
Simplify reading OLE properties

### DIFF
--- a/OpenMcdf.Ole/DictionaryProperty.cs
+++ b/OpenMcdf.Ole/DictionaryProperty.cs
@@ -2,15 +2,9 @@
 
 namespace OpenMcdf.Ole;
 
-internal sealed class DictionaryProperty : IProperty
+internal sealed class DictionaryProperty(int codePage, Dictionary<uint, string> entries) : IProperty
 {
-    private readonly int codePage;
-    private Dictionary<uint, string>? entries = new();
-
-    public DictionaryProperty(int codePage)
-    {
-        this.codePage = codePage;
-    }
+    private Dictionary<uint, string>? entries = entries;
 
     public PropertyType PropertyType => PropertyType.DictionaryProperty;
 
@@ -20,18 +14,22 @@ internal sealed class DictionaryProperty : IProperty
         set => entries = (Dictionary<uint, string>?)value;
     }
 
-    public void Read(BinaryReader br)
+    // Read a DictionaryProperty from the provided BinaryReader
+    public static DictionaryProperty Read(BinaryReader br, int codePage)
     {
         long curPos = br.BaseStream.Position;
 
+        // Read the number of entries
+        // Reserve some space in the dictionary, but clamp the size for safety.
         uint numEntries = br.ReadUInt32();
+        Dictionary<uint, string> entries = new((int)Math.Min(numEntries, 64));
 
         // Encoding.GetEncoding can actually be quite slow, so as all strings are in the same codepage, get the encoding once and then use it for each property.
         Encoding encoding = Encoding.GetEncoding(codePage);
 
         for (uint i = 0; i < numEntries; i++)
         {
-            ReadEntry(br, encoding);
+            ReadEntry(br, encoding, entries);
         }
 
         int m = (int)(br.BaseStream.Position - curPos) % 4;
@@ -43,17 +41,19 @@ internal sealed class DictionaryProperty : IProperty
                 br.ReadByte();
             }
         }
+
+        return new(codePage, entries);
     }
 
     // Read a single dictionary entry
-    private void ReadEntry(BinaryReader br, Encoding encoding)
+    private static void ReadEntry(BinaryReader br, Encoding encoding, Dictionary<uint, string> entries)
     {
         uint propertyIdentifier = br.ReadUInt32();
         int length = br.ReadInt32();
 
         byte[] nameBytes;
 
-        if (codePage == CodePages.WinUnicode)
+        if (encoding.CodePage == CodePages.WinUnicode)
         {
             nameBytes = br.ReadBytes(length << 1);
 
@@ -66,11 +66,11 @@ internal sealed class DictionaryProperty : IProperty
             nameBytes = br.ReadBytes(length);
         }
 
-        int nullByteCount = this.codePage == CodePages.WinUnicode ? 2 : 1;
+        int nullByteCount = encoding.CodePage == CodePages.WinUnicode ? 2 : 1;
         int nonNullSize = Math.Max(0, nameBytes.Length - nullByteCount);
 
         string entryName = encoding.GetString(nameBytes, 0, nonNullSize);
-        entries!.Add(propertyIdentifier, entryName);
+        entries.Add(propertyIdentifier, entryName);
     }
 
     /// <summary>

--- a/OpenMcdf.Ole/IBinarySerializable.cs
+++ b/OpenMcdf.Ole/IBinarySerializable.cs
@@ -3,6 +3,4 @@
 internal interface IBinarySerializable
 {
     void Write(BinaryWriter bw);
-
-    void Read(BinaryReader br);
 }

--- a/OpenMcdf.Ole/ITypedPropertyValue.cs
+++ b/OpenMcdf.Ole/ITypedPropertyValue.cs
@@ -14,4 +14,6 @@ internal interface ITypedPropertyValue : IProperty
     PropertyDimensions PropertyDimensions { get; }
 
     bool IsVariant { get; }
+
+    void Read(BinaryReader br);
 }

--- a/OpenMcdf.Ole/PropertyFactory.cs
+++ b/OpenMcdf.Ole/PropertyFactory.cs
@@ -44,6 +44,13 @@ internal abstract class PropertyFactory
         return pr;
     }
 
+    public ITypedPropertyValue ReadProperty(BinaryReader br, VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant = false)
+    {
+        ITypedPropertyValue propertyValue = CreateProperty(vType, codePage, propertyIdentifier, isVariant);
+        propertyValue.Read(br);
+        return propertyValue;
+    }
+
     protected virtual ITypedPropertyValue CreateLpstrProperty(VTPropertyType vType, int codePage, uint propertyIdentifier, bool isVariant) => new VT_LPSTR_Property(vType, codePage, isVariant);
 
     #region Property implementations
@@ -613,9 +620,7 @@ internal abstract class PropertyFactory
             var vType = (VTPropertyType)br.ReadUInt16();
             br.ReadUInt16(); // Ushort Padding
 
-            ITypedPropertyValue p = factory.CreateProperty(vType, codePage, propertyIdentifier, true);
-            p.Read(br);
-            return p;
+            return factory.ReadProperty(br, vType, codePage, propertyIdentifier, true);
         }
 
         public override void WriteScalarValue(BinaryWriter bw, object pValue)

--- a/OpenMcdf.Ole/PropertySet.cs
+++ b/OpenMcdf.Ole/PropertySet.cs
@@ -45,12 +45,9 @@ internal sealed class PropertySet
         br.BaseStream.Position = currPos;
     }
 
-    public void Add(IDictionary<uint, string> propertyNames)
+    public void Add(Dictionary<uint, string> propertyNames)
     {
-        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage)
-        {
-            Value = propertyNames,
-        };
+        DictionaryProperty dictionaryProperty = new(PropertyContext.CodePage, propertyNames);
         Properties.Add(dictionaryProperty);
         PropertyIdentifierAndOffsets.Add(new PropertyIdentifierAndOffset(SpecialPropertyIdentifiers.Dictionary, 0));
     }

--- a/OpenMcdf.Ole/PropertySetStream.cs
+++ b/OpenMcdf.Ole/PropertySetStream.cs
@@ -223,17 +223,12 @@ internal sealed class PropertySetStream
     {
         if (propertyIdentifier == SpecialPropertyIdentifiers.Dictionary)
         {
-            DictionaryProperty dictionaryProperty = new(codePage);
-            dictionaryProperty.Read(br);
-            return dictionaryProperty;
+            return DictionaryProperty.Read(br, codePage);
         }
 
         var vType = (VTPropertyType)br.ReadUInt16();
         br.ReadUInt16(); // Ushort Padding
 
-        ITypedPropertyValue pr = factory.CreateProperty(vType, codePage, propertyIdentifier);
-        pr.Read(br);
-
-        return pr;
+        return factory.ReadProperty(br, vType, codePage, propertyIdentifier);
     }
 }


### PR DESCRIPTION
Just a thought I had when looking at other things, and going on a bit of a tangent again.

Given that all of the property read operations create the properties and then immediately read the data, I just wondered if the multiple Create/Read pairs could be simplified into simpler Read operations.

It mainly simplifies DictionaryProperty here as I wanted to keep it simple and not change anything else about PropertyFactory